### PR TITLE
Double trimming

### DIFF
--- a/cMain.cpp
+++ b/cMain.cpp
@@ -1385,9 +1385,9 @@ std::string convertWXString(wxString s) {
 
 void cMain::grid_extract_parameters(const int &row, wxGrid* grid) {
 	task = grid->GetCellValue(row, 0).ToStdString();
-	x_cord = grid->GetCellValue(row, 1).ToStdString();
-	y_cord = grid->GetCellValue(row, 2).ToStdString();
-	units = grid->GetCellValue(row, 3).ToStdString();
+	x_cord = convertWXString(grid->GetCellValue(row, 1));
+	y_cord = convertWXString(grid->GetCellValue(row, 2));
+	units = convertWXString(grid->GetCellValue(row, 3));
 	item = grid->GetCellValue(row, 4).ToStdString();
 	build_orientation = grid->GetCellValue(row, 5).ToStdString();
 	direction_to_build = grid->GetCellValue(row, 6).ToStdString();

--- a/cMain.cpp
+++ b/cMain.cpp
@@ -1358,6 +1358,31 @@ void cMain::OnGroupAddToTasksListClicked(wxCommandEvent& event) {
 	event.Skip();
 }
 
+const char* ws = "0.";
+
+// trim from end of string (right)
+inline std::string& rtrim(std::string& s, const char* t = ws)
+{
+	s.erase(s.find_last_not_of(t) + 1);
+	if (std::empty(s)) s = "0";
+	return s;
+}
+
+std::string convertWXString(wxString s) {
+	double d = 0;
+	int i = 0;
+	std::string r;
+	if (s.ToInt(&i))
+		return std::to_string(i);
+	if (s.ToDouble(&d))
+	{
+		r = std::to_string(d);
+		return rtrim(r, ws);
+	}
+	else
+		return s.ToStdString();
+}
+
 void cMain::grid_extract_parameters(const int &row, wxGrid* grid) {
 	task = grid->GetCellValue(row, 0).ToStdString();
 	x_cord = grid->GetCellValue(row, 1).ToStdString();


### PR DESCRIPTION
Adds trimming of tracing zeroes when extracting x-cord, y-cord & units. from an existing task to the task designer. 