### PR TITLE
Hotbar autoset

### DIFF
--- a/EZRaiderz-TAS-Helper.vcxproj
+++ b/EZRaiderz-TAS-Helper.vcxproj
@@ -130,6 +130,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(WXWIN)\include; $(WXWIN)\include\msvc</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/cMain.cpp
+++ b/cMain.cpp
@@ -1809,6 +1809,7 @@ void cMain::OnMenuOpen(wxCommandEvent& event) {
 
 	if (dlg.ShowModal() == wxID_OK) {
 		std::ifstream inFile;
+#pragma warning(suppress : 4996)
 		std::locale utf8_locale(std::locale(), new std::codecvt_utf8<wchar_t>);
 		inFile.imbue(utf8_locale);
 		inFile.open(dlg.GetPath().ToStdString());

--- a/cMain.cpp
+++ b/cMain.cpp
@@ -2376,6 +2376,14 @@ void cMain::OnGenerateScript(wxCommandEvent& event) {
 
 	saver.close();
 
+	saver.open(generate_code_folder_location + "\\settings.lua");
+	saver << settings;
+	saver.close();
+
+	saver.open(generate_code_folder_location + "\\locale\\en\\locale.cfg"); //it doesn't need to be named locale but the path is important
+	saver << locale;
+	saver.close();
+
 	dialog_progress_bar->set_progress(100);
 	if (auto_close_generate_script) {
 		dialog_progress_bar->Close();

--- a/cMain.cpp
+++ b/cMain.cpp
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <locale>
 #include <codecvt>
+#include <filesystem>
 
 cMain::cMain() : GUI_Base(nullptr, wxID_ANY, window_title, wxPoint(30, 30), wxSize(1840, 950)) {
 	SetIcon(icon_xpm);
@@ -2379,6 +2380,9 @@ void cMain::OnGenerateScript(wxCommandEvent& event) {
 	saver.open(generate_code_folder_location + "\\settings.lua");
 	saver << settings;
 	saver.close();
+
+	namespace fs = std::filesystem; // create folders if they don't exist
+	fs::create_directories(generate_code_folder_location + "\\locale\\en");
 
 	saver.open(generate_code_folder_location + "\\locale\\en\\locale.cfg"); //it doesn't need to be named locale but the path is important
 	saver << locale;

--- a/control_info.h
+++ b/control_info.h
@@ -835,6 +835,29 @@ script.on_event(defines.events.script_raised_built, function(event)
 	entity.surface.play_sound{path="entity-build/"..entity.prototype.name, position=entity.position}
 end)
 
+--modsetting names are stored in a global array for all mods, so each setting value needs to be unique among all mods
+local settings_short = "DunRaider-quickbar-"
+local function split_string(str)
+	if str == nil then return end
+	local t = {}
+	for s in string.gmatch(str, "([^,]+)") do table.insert(t, s) end
+	return t
+end
+
+--seperate functions in case we want it to trigger on other events
+local function set_quick_bar(event)
+	local player = game.players[event.player_index]
+	for i = 1, 10 do 
+		local set = split_string(settings.global[settings_short..i].value)
+		for key,val in pairs(set) do
+			player.set_quick_bar_slot((i-1)*10 + key, string.sub(val, 7, -2)) -- removes "[item=" and "]"
+		end
+	end
+end
+
+script.on_event(defines.events.on_cutscene_cancelled, function(event)
+	set_quick_bar(event)
+end)
 )control_lua2";
 
 std::string control_steel_axe = R"control_lua2(

--- a/control_info.h
+++ b/control_info.h
@@ -887,6 +887,128 @@ script.on_event(defines.events.on_rocket_launched, function(event)
 end)
 )control_lua2";
 
+std::string settings = R"settings_lua(local t = {
+  basic_materials = string.format("[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s]",
+	"iron-plate","copper-plate","copper-cable","electronic-circuit","iron-gear-wheel","iron-ore","copper-ore","stone","coal","wood"),
+  gotlap = string.format("[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s]",
+	"steel-plate","iron-stick","engine-unit","automation-science-pack","logistic-science-pack","rail","locomotive","rail-signal","rail-chain-signal","train-stop"),
+  basic_logistics = string.format("[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s]",
+	"transport-belt","underground-belt","splitter","inserter","long-handed-inserter","fast-inserter","burner-inserter","filter-inserter","stack-inserter","stack-filter-inserter"),
+  basic_construction = string.format("[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s],[item=%s]",
+	"burner-mining-drill","stone-furnace","electric-mining-drill","assembling-machine-1","lab","boiler","steam-engine","offshore-pump","pipe","pipe-to-ground"),
+  none = ""
+}
+
+data:extend(
+{
+  {
+    type = "string-setting",
+    name = "DunRaider-quickbar-1",
+    setting_type = "runtime-global",
+    default_value = t.basic_materials,
+    allow_blank = true,
+    order = "q1",
+  },
+  {
+    type = "string-setting",
+    name = "DunRaider-quickbar-2",
+    setting_type = "runtime-global",
+    default_value = t.gotlap,
+    allow_blank = true,
+    order = "q2",
+  },
+  {
+    type = "string-setting",
+    name = "DunRaider-quickbar-3",
+    setting_type = "runtime-global",
+    default_value = t.basic_logistics,
+    allow_blank = true,
+    order = "q3",
+  },
+  {
+    type = "string-setting",
+    name = "DunRaider-quickbar-4",
+    setting_type = "runtime-global",
+    default_value = t.basic_construction,
+    allow_blank = true,
+    order = "q4",
+  },
+  {
+    type = "string-setting",
+    name = "DunRaider-quickbar-5",
+    setting_type = "runtime-global",
+    default_value = t.none,
+    allow_blank = true,
+    order = "q5",
+  },
+  {
+    type = "string-setting",
+    name = "DunRaider-quickbar-6",
+    setting_type = "runtime-global",
+    default_value = t.none,
+    allow_blank = true,
+    order = "q6",
+  },
+  {
+    type = "string-setting",
+    name = "DunRaider-quickbar-7",
+    setting_type = "runtime-global",
+    default_value = t.none,
+    allow_blank = true,
+    order = "q7",
+  },
+  {
+    type = "string-setting",
+    name = "DunRaider-quickbar-8",
+    setting_type = "runtime-global",
+    default_value = t.none,
+    allow_blank = true,
+    order = "q8",
+  },
+  {
+    type = "string-setting",
+    name = "DunRaider-quickbar-9",
+    setting_type = "runtime-global",
+    default_value = t.none,
+    allow_blank = true,
+    order = "q9",
+  },
+  {
+    type = "string-setting",
+    name = "DunRaider-quickbar-10",
+    setting_type = "runtime-global",
+    default_value = t.none,
+    allow_blank = true,
+    order = "q91",
+  },
+}))settings_lua";
+
+std::string locale = R"locale_cfg([mod-setting-name]
+DunRaider-quickbar-1=Hotbar 1
+DunRaider-quickbar-2=Hotbar 2
+DunRaider-quickbar-3=Hotbar 3
+DunRaider-quickbar-4=Hotbar 4
+DunRaider-quickbar-5=Hotbar 5
+DunRaider-quickbar-6=Hotbar 6
+DunRaider-quickbar-7=Hotbar 7
+DunRaider-quickbar-8=Hotbar 8
+DunRaider-quickbar-9=Hotbar 9
+DunRaider-quickbar-10=Hotbar 0
+
+
+[mod-setting-description]
+DunRaider-quickbar-1=Comma seperated list of items in the format of [item=<itemname>]
+DunRaider-quickbar-2=Comma seperated list of items in the format of [item=<itemname>]
+DunRaider-quickbar-3=Comma seperated list of items in the format of [item=<itemname>]
+DunRaider-quickbar-4=Comma seperated list of items in the format of [item=<itemname>]
+DunRaider-quickbar-5=Comma seperated list of items in the format of [item=<itemname>]
+DunRaider-quickbar-6=Comma seperated list of items in the format of [item=<itemname>]
+DunRaider-quickbar-7=Comma seperated list of items in the format of [item=<itemname>]
+DunRaider-quickbar-8=Comma seperated list of items in the format of [item=<itemname>]
+DunRaider-quickbar-9=Comma seperated list of items in the format of [item=<itemname>]
+DunRaider-quickbar-10=Comma seperated list of items in the format of [item=<itemname>]
+)locale_cfg";
+
 std::string control_debug = R"control_lua2(
 -- Debug mode
 debug_state = true


### PR DESCRIPTION
Closes #20 

Added the option to autoset the hotbar (quickbar)

- Added mod setting file, where the user can configure their hotbar items
- Added folder "locale/en"
- Added locale file to convert hotbar settings to human text
- Added split_string lua function
- Added set_quick_bar lua function to handle the conversion between settings -> hotbar
- Added event on_cutscene_cancelled that runs the set_quick_bar function

Upgraded to cpp17 to create directories "locale" and "locale/en"
Suppressed a warning due codecvt_utf8 being deprecated

I also added a few default hotbar sets, it is not an exhaustive list, just a start.