### PR TITLE
Set default value for take&put task

### DIFF
--- a/cMain.cpp
+++ b/cMain.cpp
@@ -194,6 +194,8 @@ void cMain::OnTakeChosen(wxCommandEvent& event) {
 	cmb_item->SetValue(*all_items.begin());
 	cmb_item->AutoComplete(item_choices);
 
+	cmb_from_into->SetValue("Output"); // set default to output on take task
+
 	event.Skip();
 }
 
@@ -206,6 +208,8 @@ void cMain::OnPutChosen(wxCommandEvent& event) {
 	}
 	cmb_item->SetValue(*all_items.begin());
 	cmb_item->AutoComplete(item_choices);
+
+	cmb_from_into->SetValue("Input"); // set default to input on put task
 
 	event.Skip();
 }


### PR DESCRIPTION
Adds default value to to/from field when choosing either take or put task. Which should make it slightly easier to use.

Request from zaspar:
_do you think it's possible to have the from/into box to default to output when using 'take' and input when using 'put'?
atm it just defaults to whatever I last used
so if I do a take output then the next put will default to output which I will never need to use_