### PR TITLE
Moved Buildings tab to the third tab on the lidt

### DIFF
--- a/GUI.fbp
+++ b/GUI.fbp
@@ -4507,7 +4507,7 @@
                                                             <property name="minimize_button">0</property>
                                                             <property name="minimum_size"></property>
                                                             <property name="moveable">1</property>
-                                                            <property name="name">label_tasks1</property>
+                                                            <property name="name">label_atuo_put</property>
                                                             <property name="pane_border">1</property>
                                                             <property name="pane_position"></property>
                                                             <property name="pane_size"></property>
@@ -4995,213 +4995,8 @@
                                         <property name="window_style"></property>
                                         <object class="notebookpage" expanded="0">
                                             <property name="bitmap"></property>
-                                            <property name="label">Buildings</property>
-                                            <property name="select">1</property>
-                                            <object class="wxPanel" expanded="0">
-                                                <property name="BottomDockable">1</property>
-                                                <property name="LeftDockable">1</property>
-                                                <property name="RightDockable">1</property>
-                                                <property name="TopDockable">1</property>
-                                                <property name="aui_layer"></property>
-                                                <property name="aui_name"></property>
-                                                <property name="aui_position"></property>
-                                                <property name="aui_row"></property>
-                                                <property name="best_size"></property>
-                                                <property name="bg"></property>
-                                                <property name="caption"></property>
-                                                <property name="caption_visible">1</property>
-                                                <property name="center_pane">0</property>
-                                                <property name="close_button">1</property>
-                                                <property name="context_help"></property>
-                                                <property name="context_menu">1</property>
-                                                <property name="default_pane">0</property>
-                                                <property name="dock">Dock</property>
-                                                <property name="dock_fixed">0</property>
-                                                <property name="docking">Left</property>
-                                                <property name="enabled">1</property>
-                                                <property name="fg"></property>
-                                                <property name="floatable">1</property>
-                                                <property name="font"></property>
-                                                <property name="gripper">0</property>
-                                                <property name="hidden">0</property>
-                                                <property name="id">wxID_ANY</property>
-                                                <property name="max_size"></property>
-                                                <property name="maximize_button">0</property>
-                                                <property name="maximum_size"></property>
-                                                <property name="min_size"></property>
-                                                <property name="minimize_button">0</property>
-                                                <property name="minimum_size"></property>
-                                                <property name="moveable">1</property>
-                                                <property name="name">m_panel61</property>
-                                                <property name="pane_border">1</property>
-                                                <property name="pane_position"></property>
-                                                <property name="pane_size"></property>
-                                                <property name="permission">protected</property>
-                                                <property name="pin_button">1</property>
-                                                <property name="pos"></property>
-                                                <property name="resize">Resizable</property>
-                                                <property name="show">1</property>
-                                                <property name="size"></property>
-                                                <property name="subclass">; ; forward_declare</property>
-                                                <property name="toolbar_pane">0</property>
-                                                <property name="tooltip"></property>
-                                                <property name="window_extra_style"></property>
-                                                <property name="window_name"></property>
-                                                <property name="window_style">wxTAB_TRAVERSAL</property>
-                                                <object class="wxBoxSizer" expanded="0">
-                                                    <property name="minimum_size"></property>
-                                                    <property name="name">bSizer56111</property>
-                                                    <property name="orient">wxVERTICAL</property>
-                                                    <property name="permission">none</property>
-                                                    <object class="sizeritem" expanded="0">
-                                                        <property name="border">5</property>
-                                                        <property name="flag">wxEXPAND</property>
-                                                        <property name="proportion">1</property>
-                                                        <object class="wxBoxSizer" expanded="0">
-                                                            <property name="minimum_size"></property>
-                                                            <property name="name">bSizer100121</property>
-                                                            <property name="orient">wxHORIZONTAL</property>
-                                                            <property name="permission">none</property>
-                                                            <object class="sizeritem" expanded="0">
-                                                                <property name="border">5</property>
-                                                                <property name="flag">wxEXPAND</property>
-                                                                <property name="proportion">1</property>
-                                                                <object class="spacer" expanded="0">
-                                                                    <property name="height">36</property>
-                                                                    <property name="permission">protected</property>
-                                                                    <property name="width">0</property>
-                                                                </object>
-                                                            </object>
-                                                        </object>
-                                                    </object>
-                                                    <object class="sizeritem" expanded="0">
-                                                        <property name="border">5</property>
-                                                        <property name="flag">wxEXPAND</property>
-                                                        <property name="proportion">1</property>
-                                                        <object class="wxBoxSizer" expanded="0">
-                                                            <property name="minimum_size"></property>
-                                                            <property name="name">bSizer1001211</property>
-                                                            <property name="orient">wxHORIZONTAL</property>
-                                                            <property name="permission">none</property>
-                                                            <object class="sizeritem" expanded="0">
-                                                                <property name="border">5</property>
-                                                                <property name="flag">wxEXPAND</property>
-                                                                <property name="proportion">1</property>
-                                                                <object class="spacer" expanded="0">
-                                                                    <property name="height">36</property>
-                                                                    <property name="permission">protected</property>
-                                                                    <property name="width">0</property>
-                                                                </object>
-                                                            </object>
-                                                        </object>
-                                                    </object>
-                                                    <object class="sizeritem" expanded="0">
-                                                        <property name="border">5</property>
-                                                        <property name="flag"></property>
-                                                        <property name="proportion">1</property>
-                                                        <object class="wxBoxSizer" expanded="0">
-                                                            <property name="minimum_size"></property>
-                                                            <property name="name">bSizer5011</property>
-                                                            <property name="orient">wxVERTICAL</property>
-                                                            <property name="permission">none</property>
-                                                            <object class="sizeritem" expanded="0">
-                                                                <property name="border">5</property>
-                                                                <property name="flag">wxALL</property>
-                                                                <property name="proportion">0</property>
-                                                                <object class="wxGrid" expanded="0">
-                                                                    <property name="BottomDockable">1</property>
-                                                                    <property name="LeftDockable">1</property>
-                                                                    <property name="RightDockable">1</property>
-                                                                    <property name="TopDockable">1</property>
-                                                                    <property name="aui_layer"></property>
-                                                                    <property name="aui_name"></property>
-                                                                    <property name="aui_position"></property>
-                                                                    <property name="aui_row"></property>
-                                                                    <property name="autosize_cols">0</property>
-                                                                    <property name="autosize_rows">0</property>
-                                                                    <property name="best_size"></property>
-                                                                    <property name="bg"></property>
-                                                                    <property name="caption"></property>
-                                                                    <property name="caption_visible">1</property>
-                                                                    <property name="cell_bg"></property>
-                                                                    <property name="cell_font"></property>
-                                                                    <property name="cell_horiz_alignment">wxALIGN_LEFT</property>
-                                                                    <property name="cell_text"></property>
-                                                                    <property name="cell_vert_alignment">wxALIGN_TOP</property>
-                                                                    <property name="center_pane">0</property>
-                                                                    <property name="close_button">1</property>
-                                                                    <property name="col_label_horiz_alignment">wxALIGN_CENTER</property>
-                                                                    <property name="col_label_size"></property>
-                                                                    <property name="col_label_values">&quot;X-cord&quot; &quot;Y-cord&quot; &quot;Building&quot; &quot;Orientation&quot; &quot;Limit&quot; &quot;Recipe&quot; &quot;Prio In&quot; &quot;Prio Out&quot; &quot;Filter&quot;</property>
-                                                                    <property name="col_label_vert_alignment">wxALIGN_CENTER</property>
-                                                                    <property name="cols">9</property>
-                                                                    <property name="column_sizes">50,50,150,70,50,150,50,50,150</property>
-                                                                    <property name="context_help"></property>
-                                                                    <property name="context_menu">1</property>
-                                                                    <property name="default_pane">0</property>
-                                                                    <property name="dock">Dock</property>
-                                                                    <property name="dock_fixed">0</property>
-                                                                    <property name="docking">Left</property>
-                                                                    <property name="drag_col_move">0</property>
-                                                                    <property name="drag_col_size">0</property>
-                                                                    <property name="drag_grid_size">0</property>
-                                                                    <property name="drag_row_size">0</property>
-                                                                    <property name="editing">0</property>
-                                                                    <property name="enabled">1</property>
-                                                                    <property name="fg"></property>
-                                                                    <property name="floatable">1</property>
-                                                                    <property name="font"></property>
-                                                                    <property name="grid_line_color"></property>
-                                                                    <property name="grid_lines">1</property>
-                                                                    <property name="gripper">0</property>
-                                                                    <property name="hidden">0</property>
-                                                                    <property name="id">wxID_ANY</property>
-                                                                    <property name="label_bg"></property>
-                                                                    <property name="label_font"></property>
-                                                                    <property name="label_text"></property>
-                                                                    <property name="margin_height">0</property>
-                                                                    <property name="margin_width">0</property>
-                                                                    <property name="max_size"></property>
-                                                                    <property name="maximize_button">0</property>
-                                                                    <property name="maximum_size"></property>
-                                                                    <property name="min_size"></property>
-                                                                    <property name="minimize_button">0</property>
-                                                                    <property name="minimum_size">870,2500</property>
-                                                                    <property name="moveable">1</property>
-                                                                    <property name="name">grid_buildings</property>
-                                                                    <property name="pane_border">1</property>
-                                                                    <property name="pane_position"></property>
-                                                                    <property name="pane_size"></property>
-                                                                    <property name="permission">protected</property>
-                                                                    <property name="pin_button">1</property>
-                                                                    <property name="pos"></property>
-                                                                    <property name="resize">Resizable</property>
-                                                                    <property name="row_label_horiz_alignment">wxALIGN_CENTER</property>
-                                                                    <property name="row_label_size"></property>
-                                                                    <property name="row_label_values"></property>
-                                                                    <property name="row_label_vert_alignment">wxALIGN_CENTER</property>
-                                                                    <property name="row_sizes"></property>
-                                                                    <property name="rows">0</property>
-                                                                    <property name="show">1</property>
-                                                                    <property name="size">825,-1</property>
-                                                                    <property name="subclass">; ; forward_declare</property>
-                                                                    <property name="toolbar_pane">0</property>
-                                                                    <property name="tooltip"></property>
-                                                                    <property name="window_extra_style"></property>
-                                                                    <property name="window_name"></property>
-                                                                    <property name="window_style"></property>
-                                                                    <event name="OnGridCellLeftDClick">OnBuildingsGridLeftDoubleClick</event>
-                                                                </object>
-                                                            </object>
-                                                        </object>
-                                                    </object>
-                                                </object>
-                                            </object>
-                                        </object>
-                                        <object class="notebookpage" expanded="0">
-                                            <property name="bitmap"></property>
                                             <property name="label">Group</property>
-                                            <property name="select">0</property>
+                                            <property name="select">1</property>
                                             <object class="wxPanel" expanded="0">
                                                 <property name="BottomDockable">1</property>
                                                 <property name="LeftDockable">1</property>
@@ -6160,7 +5955,7 @@
                                             <property name="bitmap"></property>
                                             <property name="label">Template</property>
                                             <property name="select">0</property>
-                                            <object class="wxPanel" expanded="1">
+                                            <object class="wxPanel" expanded="0">
                                                 <property name="BottomDockable">1</property>
                                                 <property name="LeftDockable">1</property>
                                                 <property name="RightDockable">1</property>
@@ -7391,6 +7186,211 @@
                                                                     <property name="window_name"></property>
                                                                     <property name="window_style"></property>
                                                                     <event name="OnGridCellLeftDClick">OnTemplateGridDoubleLeftClick</event>
+                                                                </object>
+                                                            </object>
+                                                        </object>
+                                                    </object>
+                                                </object>
+                                            </object>
+                                        </object>
+                                        <object class="notebookpage" expanded="0">
+                                            <property name="bitmap"></property>
+                                            <property name="label">Buildings</property>
+                                            <property name="select">0</property>
+                                            <object class="wxPanel" expanded="0">
+                                                <property name="BottomDockable">1</property>
+                                                <property name="LeftDockable">1</property>
+                                                <property name="RightDockable">1</property>
+                                                <property name="TopDockable">1</property>
+                                                <property name="aui_layer"></property>
+                                                <property name="aui_name"></property>
+                                                <property name="aui_position"></property>
+                                                <property name="aui_row"></property>
+                                                <property name="best_size"></property>
+                                                <property name="bg"></property>
+                                                <property name="caption"></property>
+                                                <property name="caption_visible">1</property>
+                                                <property name="center_pane">0</property>
+                                                <property name="close_button">1</property>
+                                                <property name="context_help"></property>
+                                                <property name="context_menu">1</property>
+                                                <property name="default_pane">0</property>
+                                                <property name="dock">Dock</property>
+                                                <property name="dock_fixed">0</property>
+                                                <property name="docking">Left</property>
+                                                <property name="enabled">1</property>
+                                                <property name="fg"></property>
+                                                <property name="floatable">1</property>
+                                                <property name="font"></property>
+                                                <property name="gripper">0</property>
+                                                <property name="hidden">0</property>
+                                                <property name="id">wxID_ANY</property>
+                                                <property name="max_size"></property>
+                                                <property name="maximize_button">0</property>
+                                                <property name="maximum_size"></property>
+                                                <property name="min_size"></property>
+                                                <property name="minimize_button">0</property>
+                                                <property name="minimum_size"></property>
+                                                <property name="moveable">1</property>
+                                                <property name="name">m_panel61</property>
+                                                <property name="pane_border">1</property>
+                                                <property name="pane_position"></property>
+                                                <property name="pane_size"></property>
+                                                <property name="permission">protected</property>
+                                                <property name="pin_button">1</property>
+                                                <property name="pos"></property>
+                                                <property name="resize">Resizable</property>
+                                                <property name="show">1</property>
+                                                <property name="size"></property>
+                                                <property name="subclass">; ; forward_declare</property>
+                                                <property name="toolbar_pane">0</property>
+                                                <property name="tooltip"></property>
+                                                <property name="window_extra_style"></property>
+                                                <property name="window_name"></property>
+                                                <property name="window_style">wxTAB_TRAVERSAL</property>
+                                                <object class="wxBoxSizer" expanded="0">
+                                                    <property name="minimum_size"></property>
+                                                    <property name="name">bSizer56111</property>
+                                                    <property name="orient">wxVERTICAL</property>
+                                                    <property name="permission">none</property>
+                                                    <object class="sizeritem" expanded="0">
+                                                        <property name="border">5</property>
+                                                        <property name="flag">wxEXPAND</property>
+                                                        <property name="proportion">1</property>
+                                                        <object class="wxBoxSizer" expanded="0">
+                                                            <property name="minimum_size"></property>
+                                                            <property name="name">bSizer100121</property>
+                                                            <property name="orient">wxHORIZONTAL</property>
+                                                            <property name="permission">none</property>
+                                                            <object class="sizeritem" expanded="0">
+                                                                <property name="border">5</property>
+                                                                <property name="flag">wxEXPAND</property>
+                                                                <property name="proportion">1</property>
+                                                                <object class="spacer" expanded="0">
+                                                                    <property name="height">36</property>
+                                                                    <property name="permission">protected</property>
+                                                                    <property name="width">0</property>
+                                                                </object>
+                                                            </object>
+                                                        </object>
+                                                    </object>
+                                                    <object class="sizeritem" expanded="0">
+                                                        <property name="border">5</property>
+                                                        <property name="flag">wxEXPAND</property>
+                                                        <property name="proportion">1</property>
+                                                        <object class="wxBoxSizer" expanded="0">
+                                                            <property name="minimum_size"></property>
+                                                            <property name="name">bSizer1001211</property>
+                                                            <property name="orient">wxHORIZONTAL</property>
+                                                            <property name="permission">none</property>
+                                                            <object class="sizeritem" expanded="0">
+                                                                <property name="border">5</property>
+                                                                <property name="flag">wxEXPAND</property>
+                                                                <property name="proportion">1</property>
+                                                                <object class="spacer" expanded="0">
+                                                                    <property name="height">36</property>
+                                                                    <property name="permission">protected</property>
+                                                                    <property name="width">0</property>
+                                                                </object>
+                                                            </object>
+                                                        </object>
+                                                    </object>
+                                                    <object class="sizeritem" expanded="0">
+                                                        <property name="border">5</property>
+                                                        <property name="flag"></property>
+                                                        <property name="proportion">1</property>
+                                                        <object class="wxBoxSizer" expanded="0">
+                                                            <property name="minimum_size"></property>
+                                                            <property name="name">bSizer5011</property>
+                                                            <property name="orient">wxVERTICAL</property>
+                                                            <property name="permission">none</property>
+                                                            <object class="sizeritem" expanded="0">
+                                                                <property name="border">5</property>
+                                                                <property name="flag">wxALL</property>
+                                                                <property name="proportion">0</property>
+                                                                <object class="wxGrid" expanded="0">
+                                                                    <property name="BottomDockable">1</property>
+                                                                    <property name="LeftDockable">1</property>
+                                                                    <property name="RightDockable">1</property>
+                                                                    <property name="TopDockable">1</property>
+                                                                    <property name="aui_layer"></property>
+                                                                    <property name="aui_name"></property>
+                                                                    <property name="aui_position"></property>
+                                                                    <property name="aui_row"></property>
+                                                                    <property name="autosize_cols">0</property>
+                                                                    <property name="autosize_rows">0</property>
+                                                                    <property name="best_size"></property>
+                                                                    <property name="bg"></property>
+                                                                    <property name="caption"></property>
+                                                                    <property name="caption_visible">1</property>
+                                                                    <property name="cell_bg"></property>
+                                                                    <property name="cell_font"></property>
+                                                                    <property name="cell_horiz_alignment">wxALIGN_LEFT</property>
+                                                                    <property name="cell_text"></property>
+                                                                    <property name="cell_vert_alignment">wxALIGN_TOP</property>
+                                                                    <property name="center_pane">0</property>
+                                                                    <property name="close_button">1</property>
+                                                                    <property name="col_label_horiz_alignment">wxALIGN_CENTER</property>
+                                                                    <property name="col_label_size"></property>
+                                                                    <property name="col_label_values">&quot;X-cord&quot; &quot;Y-cord&quot; &quot;Building&quot; &quot;Orientation&quot; &quot;Limit&quot; &quot;Recipe&quot; &quot;Prio In&quot; &quot;Prio Out&quot; &quot;Filter&quot;</property>
+                                                                    <property name="col_label_vert_alignment">wxALIGN_CENTER</property>
+                                                                    <property name="cols">9</property>
+                                                                    <property name="column_sizes">50,50,150,70,50,150,50,50,150</property>
+                                                                    <property name="context_help"></property>
+                                                                    <property name="context_menu">1</property>
+                                                                    <property name="default_pane">0</property>
+                                                                    <property name="dock">Dock</property>
+                                                                    <property name="dock_fixed">0</property>
+                                                                    <property name="docking">Left</property>
+                                                                    <property name="drag_col_move">0</property>
+                                                                    <property name="drag_col_size">0</property>
+                                                                    <property name="drag_grid_size">0</property>
+                                                                    <property name="drag_row_size">0</property>
+                                                                    <property name="editing">0</property>
+                                                                    <property name="enabled">1</property>
+                                                                    <property name="fg"></property>
+                                                                    <property name="floatable">1</property>
+                                                                    <property name="font"></property>
+                                                                    <property name="grid_line_color"></property>
+                                                                    <property name="grid_lines">1</property>
+                                                                    <property name="gripper">0</property>
+                                                                    <property name="hidden">0</property>
+                                                                    <property name="id">wxID_ANY</property>
+                                                                    <property name="label_bg"></property>
+                                                                    <property name="label_font"></property>
+                                                                    <property name="label_text"></property>
+                                                                    <property name="margin_height">0</property>
+                                                                    <property name="margin_width">0</property>
+                                                                    <property name="max_size"></property>
+                                                                    <property name="maximize_button">0</property>
+                                                                    <property name="maximum_size"></property>
+                                                                    <property name="min_size"></property>
+                                                                    <property name="minimize_button">0</property>
+                                                                    <property name="minimum_size">870,2500</property>
+                                                                    <property name="moveable">1</property>
+                                                                    <property name="name">grid_buildings</property>
+                                                                    <property name="pane_border">1</property>
+                                                                    <property name="pane_position"></property>
+                                                                    <property name="pane_size"></property>
+                                                                    <property name="permission">protected</property>
+                                                                    <property name="pin_button">1</property>
+                                                                    <property name="pos"></property>
+                                                                    <property name="resize">Resizable</property>
+                                                                    <property name="row_label_horiz_alignment">wxALIGN_CENTER</property>
+                                                                    <property name="row_label_size"></property>
+                                                                    <property name="row_label_values"></property>
+                                                                    <property name="row_label_vert_alignment">wxALIGN_CENTER</property>
+                                                                    <property name="row_sizes"></property>
+                                                                    <property name="rows">0</property>
+                                                                    <property name="show">1</property>
+                                                                    <property name="size">825,-1</property>
+                                                                    <property name="subclass">; ; forward_declare</property>
+                                                                    <property name="toolbar_pane">0</property>
+                                                                    <property name="tooltip"></property>
+                                                                    <property name="window_extra_style"></property>
+                                                                    <property name="window_name"></property>
+                                                                    <property name="window_style"></property>
+                                                                    <event name="OnGridCellLeftDClick">OnBuildingsGridLeftDoubleClick</event>
                                                                 </object>
                                                             </object>
                                                         </object>

--- a/GUI_Base.cpp
+++ b/GUI_Base.cpp
@@ -725,83 +725,6 @@ GUI_Base::GUI_Base(wxWindow* parent, wxWindowID id, const wxString& title, const
 
 	bSizer44->SetMinSize(wxSize(550, -1));
 	m_notebook1 = new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0);
-	m_panel61 = new wxPanel(m_notebook1, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
-	wxBoxSizer* bSizer56111;
-	bSizer56111 = new wxBoxSizer(wxVERTICAL);
-
-	wxBoxSizer* bSizer100121;
-	bSizer100121 = new wxBoxSizer(wxHORIZONTAL);
-
-
-	bSizer100121->Add(0, 36, 1, wxEXPAND, 5);
-
-
-	bSizer56111->Add(bSizer100121, 1, wxEXPAND, 5);
-
-	wxBoxSizer* bSizer1001211;
-	bSizer1001211 = new wxBoxSizer(wxHORIZONTAL);
-
-
-	bSizer1001211->Add(0, 36, 1, wxEXPAND, 5);
-
-
-	bSizer56111->Add(bSizer1001211, 1, wxEXPAND, 5);
-
-	wxBoxSizer* bSizer5011;
-	bSizer5011 = new wxBoxSizer(wxVERTICAL);
-
-	grid_buildings = new wxGrid(m_panel61, wxID_ANY, wxDefaultPosition, wxSize(825, -1), 0);
-
-	// Grid
-	grid_buildings->CreateGrid(0, 9);
-	grid_buildings->EnableEditing(false);
-	grid_buildings->EnableGridLines(true);
-	grid_buildings->EnableDragGridSize(false);
-	grid_buildings->SetMargins(0, 0);
-
-	// Columns
-	grid_buildings->SetColSize(0, 50);
-	grid_buildings->SetColSize(1, 50);
-	grid_buildings->SetColSize(2, 150);
-	grid_buildings->SetColSize(3, 70);
-	grid_buildings->SetColSize(4, 50);
-	grid_buildings->SetColSize(5, 150);
-	grid_buildings->SetColSize(6, 50);
-	grid_buildings->SetColSize(7, 50);
-	grid_buildings->SetColSize(8, 150);
-	grid_buildings->EnableDragColMove(false);
-	grid_buildings->EnableDragColSize(false);
-	grid_buildings->SetColLabelValue(0, wxT("X-cord"));
-	grid_buildings->SetColLabelValue(1, wxT("Y-cord"));
-	grid_buildings->SetColLabelValue(2, wxT("Building"));
-	grid_buildings->SetColLabelValue(3, wxT("Orientation"));
-	grid_buildings->SetColLabelValue(4, wxT("Limit"));
-	grid_buildings->SetColLabelValue(5, wxT("Recipe"));
-	grid_buildings->SetColLabelValue(6, wxT("Prio In"));
-	grid_buildings->SetColLabelValue(7, wxT("Prio Out"));
-	grid_buildings->SetColLabelValue(8, wxT("Filter"));
-	grid_buildings->SetColLabelAlignment(wxALIGN_CENTER, wxALIGN_CENTER);
-
-	// Rows
-	grid_buildings->EnableDragRowSize(false);
-	grid_buildings->SetRowLabelAlignment(wxALIGN_CENTER, wxALIGN_CENTER);
-
-	// Label Appearance
-
-	// Cell Defaults
-	grid_buildings->SetDefaultCellAlignment(wxALIGN_LEFT, wxALIGN_TOP);
-	grid_buildings->SetMinSize(wxSize(870, 2500));
-
-	bSizer5011->Add(grid_buildings, 0, wxALL, 5);
-
-
-	bSizer56111->Add(bSizer5011, 1, 0, 5);
-
-
-	m_panel61->SetSizer(bSizer56111);
-	m_panel61->Layout();
-	bSizer56111->Fit(m_panel61);
-	m_notebook1->AddPage(m_panel61, wxT("Buildings"), true);
 	m_panel3 = new wxPanel(m_notebook1, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
 	wxBoxSizer* bSizer561;
 	bSizer561 = new wxBoxSizer(wxVERTICAL);
@@ -934,7 +857,7 @@ GUI_Base::GUI_Base(wxWindow* parent, wxWindowID id, const wxString& title, const
 	m_panel3->SetSizer(bSizer561);
 	m_panel3->Layout();
 	bSizer561->Fit(m_panel3);
-	m_notebook1->AddPage(m_panel3, wxT("Group"), false);
+	m_notebook1->AddPage(m_panel3, wxT("Group"), true);
 	m_panel6 = new wxPanel(m_notebook1, wxID_ANY, wxDefaultPosition, wxSize(-1, -1), wxTAB_TRAVERSAL);
 	wxBoxSizer* bSizer5612;
 	bSizer5612 = new wxBoxSizer(wxVERTICAL);
@@ -1104,6 +1027,83 @@ GUI_Base::GUI_Base(wxWindow* parent, wxWindowID id, const wxString& title, const
 	m_panel6->Layout();
 	bSizer5612->Fit(m_panel6);
 	m_notebook1->AddPage(m_panel6, wxT("Template"), false);
+	m_panel61 = new wxPanel(m_notebook1, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+	wxBoxSizer* bSizer56111;
+	bSizer56111 = new wxBoxSizer(wxVERTICAL);
+
+	wxBoxSizer* bSizer100121;
+	bSizer100121 = new wxBoxSizer(wxHORIZONTAL);
+
+
+	bSizer100121->Add(0, 36, 1, wxEXPAND, 5);
+
+
+	bSizer56111->Add(bSizer100121, 1, wxEXPAND, 5);
+
+	wxBoxSizer* bSizer1001211;
+	bSizer1001211 = new wxBoxSizer(wxHORIZONTAL);
+
+
+	bSizer1001211->Add(0, 36, 1, wxEXPAND, 5);
+
+
+	bSizer56111->Add(bSizer1001211, 1, wxEXPAND, 5);
+
+	wxBoxSizer* bSizer5011;
+	bSizer5011 = new wxBoxSizer(wxVERTICAL);
+
+	grid_buildings = new wxGrid(m_panel61, wxID_ANY, wxDefaultPosition, wxSize(825, -1), 0);
+
+	// Grid
+	grid_buildings->CreateGrid(0, 9);
+	grid_buildings->EnableEditing(false);
+	grid_buildings->EnableGridLines(true);
+	grid_buildings->EnableDragGridSize(false);
+	grid_buildings->SetMargins(0, 0);
+
+	// Columns
+	grid_buildings->SetColSize(0, 50);
+	grid_buildings->SetColSize(1, 50);
+	grid_buildings->SetColSize(2, 150);
+	grid_buildings->SetColSize(3, 70);
+	grid_buildings->SetColSize(4, 50);
+	grid_buildings->SetColSize(5, 150);
+	grid_buildings->SetColSize(6, 50);
+	grid_buildings->SetColSize(7, 50);
+	grid_buildings->SetColSize(8, 150);
+	grid_buildings->EnableDragColMove(false);
+	grid_buildings->EnableDragColSize(false);
+	grid_buildings->SetColLabelValue(0, wxT("X-cord"));
+	grid_buildings->SetColLabelValue(1, wxT("Y-cord"));
+	grid_buildings->SetColLabelValue(2, wxT("Building"));
+	grid_buildings->SetColLabelValue(3, wxT("Orientation"));
+	grid_buildings->SetColLabelValue(4, wxT("Limit"));
+	grid_buildings->SetColLabelValue(5, wxT("Recipe"));
+	grid_buildings->SetColLabelValue(6, wxT("Prio In"));
+	grid_buildings->SetColLabelValue(7, wxT("Prio Out"));
+	grid_buildings->SetColLabelValue(8, wxT("Filter"));
+	grid_buildings->SetColLabelAlignment(wxALIGN_CENTER, wxALIGN_CENTER);
+
+	// Rows
+	grid_buildings->EnableDragRowSize(false);
+	grid_buildings->SetRowLabelAlignment(wxALIGN_CENTER, wxALIGN_CENTER);
+
+	// Label Appearance
+
+	// Cell Defaults
+	grid_buildings->SetDefaultCellAlignment(wxALIGN_LEFT, wxALIGN_TOP);
+	grid_buildings->SetMinSize(wxSize(870, 2500));
+
+	bSizer5011->Add(grid_buildings, 0, wxALL, 5);
+
+
+	bSizer56111->Add(bSizer5011, 1, 0, 5);
+
+
+	m_panel61->SetSizer(bSizer56111);
+	m_panel61->Layout();
+	bSizer56111->Fit(m_panel61);
+	m_notebook1->AddPage(m_panel61, wxT("Buildings"), false);
 
 	bSizer44->Add(m_notebook1, 1, wxEXPAND | wxALL, 5);
 
@@ -1299,7 +1299,6 @@ GUI_Base::GUI_Base(wxWindow* parent, wxWindowID id, const wxString& title, const
 	rbtn_launch->Connect(wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler(GUI_Base::OnLaunchChosen), NULL, this);
 	rbtn_save->Connect(wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler(GUI_Base::OnSaveChosen), NULL, this);
 	rbtn_stop->Connect(wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler(GUI_Base::OnStopChosen), NULL, this);
-	grid_buildings->Connect(wxEVT_GRID_CELL_LEFT_DCLICK, wxGridEventHandler(GUI_Base::OnBuildingsGridLeftDoubleClick), NULL, this);
 	cmb_choose_group->Connect(wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler(GUI_Base::OnGroupChosen), NULL, this);
 	btn_new_group->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnNewGroupClicked), NULL, this);
 	btn_group_delete->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnDeleteGroupClicked), NULL, this);
@@ -1320,6 +1319,7 @@ GUI_Base::GUI_Base(wxWindow* parent, wxWindowID id, const wxString& title, const
 	btn_template_add_to_tasks_list1->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnTemplateAddToTasksListClicked), NULL, this);
 	btn_template_add_from_tasks_list1->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnTemplateAddFromTasksListClicked), NULL, this);
 	grid_template->Connect(wxEVT_GRID_CELL_LEFT_DCLICK, wxGridEventHandler(GUI_Base::OnTemplateGridDoubleLeftClick), NULL, this);
+	grid_buildings->Connect(wxEVT_GRID_CELL_LEFT_DCLICK, wxGridEventHandler(GUI_Base::OnBuildingsGridLeftDoubleClick), NULL, this);
 	btn_add_task11->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnAddTaskClicked), NULL, this);
 	btn_change_task11->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnChangeTaskClicked), NULL, this);
 	btn_delete_task11->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnDeleteTaskClicked), NULL, this);
@@ -1353,7 +1353,6 @@ GUI_Base::~GUI_Base()
 	rbtn_launch->Disconnect(wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler(GUI_Base::OnLaunchChosen), NULL, this);
 	rbtn_save->Disconnect(wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler(GUI_Base::OnSaveChosen), NULL, this);
 	rbtn_stop->Disconnect(wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler(GUI_Base::OnStopChosen), NULL, this);
-	grid_buildings->Disconnect(wxEVT_GRID_CELL_LEFT_DCLICK, wxGridEventHandler(GUI_Base::OnBuildingsGridLeftDoubleClick), NULL, this);
 	cmb_choose_group->Disconnect(wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler(GUI_Base::OnGroupChosen), NULL, this);
 	btn_new_group->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnNewGroupClicked), NULL, this);
 	btn_group_delete->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnDeleteGroupClicked), NULL, this);
@@ -1374,6 +1373,7 @@ GUI_Base::~GUI_Base()
 	btn_template_add_to_tasks_list1->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnTemplateAddToTasksListClicked), NULL, this);
 	btn_template_add_from_tasks_list1->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnTemplateAddFromTasksListClicked), NULL, this);
 	grid_template->Disconnect(wxEVT_GRID_CELL_LEFT_DCLICK, wxGridEventHandler(GUI_Base::OnTemplateGridDoubleLeftClick), NULL, this);
+	grid_buildings->Disconnect(wxEVT_GRID_CELL_LEFT_DCLICK, wxGridEventHandler(GUI_Base::OnBuildingsGridLeftDoubleClick), NULL, this);
 	btn_add_task11->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnAddTaskClicked), NULL, this);
 	btn_change_task11->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnChangeTaskClicked), NULL, this);
 	btn_delete_task11->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GUI_Base::OnDeleteTaskClicked), NULL, this);

--- a/GUI_Base.h
+++ b/GUI_Base.h
@@ -26,8 +26,8 @@
 #include <wx/radiobut.h>
 #include <wx/checkbox.h>
 #include <wx/panel.h>
-#include <wx/grid.h>
 #include <wx/button.h>
+#include <wx/grid.h>
 #include <wx/notebook.h>
 #include <wx/frame.h>
 #include <wx/scrolwin.h>
@@ -110,8 +110,6 @@ protected:
 	wxCheckBox* check_recipe;
 	wxStaticLine* m_staticline14;
 	wxNotebook* m_notebook1;
-	wxPanel* m_panel61;
-	wxGrid* grid_buildings;
 	wxPanel* m_panel3;
 	wxStaticText* label_choose_group;
 	wxComboBox* cmb_choose_group;
@@ -140,6 +138,8 @@ protected:
 	wxStaticText* label_template_y_offset;
 	wxTextCtrl* txt_template_y_offset;
 	wxGrid* grid_template;
+	wxPanel* m_panel61;
+	wxGrid* grid_buildings;
 	wxNotebook* m_notebook11;
 	wxPanel* m_panel31;
 	wxButton* btn_add_task11;
@@ -215,7 +215,6 @@ protected:
 	virtual void OnLaunchChosen(wxCommandEvent& event) { event.Skip(); }
 	virtual void OnSaveChosen(wxCommandEvent& event) { event.Skip(); }
 	virtual void OnStopChosen(wxCommandEvent& event) { event.Skip(); }
-	virtual void OnBuildingsGridLeftDoubleClick(wxGridEvent& event) { event.Skip(); }
 	virtual void OnGroupChosen(wxCommandEvent& event) { event.Skip(); }
 	virtual void OnNewGroupClicked(wxCommandEvent& event) { event.Skip(); }
 	virtual void OnDeleteGroupClicked(wxCommandEvent& event) { event.Skip(); }
@@ -236,6 +235,7 @@ protected:
 	virtual void OnTemplateAddToTasksListClicked(wxCommandEvent& event) { event.Skip(); }
 	virtual void OnTemplateAddFromTasksListClicked(wxCommandEvent& event) { event.Skip(); }
 	virtual void OnTemplateGridDoubleLeftClick(wxGridEvent& event) { event.Skip(); }
+	virtual void OnBuildingsGridLeftDoubleClick(wxGridEvent& event) { event.Skip(); }
 	virtual void OnAddTaskClicked(wxCommandEvent& event) { event.Skip(); }
 	virtual void OnChangeTaskClicked(wxCommandEvent& event) { event.Skip(); }
 	virtual void OnDeleteTaskClicked(wxCommandEvent& event) { event.Skip(); }


### PR DESCRIPTION
During my testing I found it a little frustrating to have buildings selected by default, so I have moved it to the third tab instead.