### PR TITLE
Custom fast replace underground

### DIFF
--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -314,7 +314,7 @@ local function create_entity_replace()
 		local can_replace_all = entities_between_length == #entities_between
 
 		--chech that all entities betweeen are in the same direction
-		if can_replace_all and not created_entity.name == "pipe-to-ground" then --ignore direction for pipes
+		if can_replace_all and created_entity.name ~= "pipe-to-ground" then --ignore direction for pipes
 			for __, e in pairs(entities_between) do
 				if e.direction ~= created_entity.direction then
 					can_replace_all = false

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -332,7 +332,9 @@ local function create_entity_replace()
 	end
 
 	--no special fast replace handling
-	player.remove_item({name = item, count = 1})
+	if created_entity then
+		player.remove_item({name = item, count = 1})
+	end
 	return created_entity ~= nil
 end
 

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -307,7 +307,9 @@ local function create_entity_replace()
 			return true
 		end
 
-		local entities_between = player.surface.find_entities_filtered{area = {created_entity.position, neighbour_position}, name = replace_type}
+		local entities_between = player.surface.find_entities_filtered{name = replace_type, area = {
+			{x=math.min(created_entity.position.x, neighbour_position.x), y=math.min(created_entity.position.y, neighbour_position.y)},
+			{x=math.max(created_entity.position.x, neighbour_position.x), y=math.max(created_entity.position.y, neighbour_position.y)}}}
 		local entities_between_length = math.abs(created_entity.position.x - neighbour_position.x + created_entity.position.y - neighbour_position.y) - 1
 		local can_replace_all = entities_between_length == #entities_between
 

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -323,7 +323,7 @@ local function create_entity_replace()
 		--mine all entities inbetween
 		if can_replace_all then
 			for __, e in pairs(entities_between) do
-				e.mine{player.character.get_main_inventory(), true, true, false}
+				player.mine_entity(e, true)
 			end
 		end
 		--spend the item placed

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -321,6 +321,23 @@ local function create_entity_replace()
 					break
 				end
 			end
+		elseif can_replace_all and created_entity.name == "pipe-to-ground" then
+			for __, e in pairs(entities_between) do --check all entities
+				if e.neighbours and e.neighbours[1] then -- null check
+					for ___, n in pairs(e.neighbours[1]) do --check all neighbours for each entity
+						for i = 1, #entities_between do --make sure it exist every neighbour is only part of the set of entities between
+							if entities_between[i] == n then
+								can_replace_all = true
+								break --break out when found
+							else
+								can_replace_all = false
+							end
+						end
+						if not can_replace_all then break end --previous loop didn't find it
+					end
+				end
+				if not can_replace_all then break end --break out
+			end
 		end
 		--mine all entities inbetween
 		if can_replace_all then


### PR DESCRIPTION
### Custom handling of fast replacing underground-belt and pipe-to-ground with belts/pipes in between
As mentioned in #90 fast replacing belts/pipes wasn't working correctly
It turns out it is a missing feature [create_entity](https://lua-api.factorio.com/latest/LuaSurface.html#LuaSurface.create_entity) where the field fast_replace promises `If true, building will attempt to simulate fast-replace building.` which doesn't hold true for creating a pair of undergrounds with belts or pipes inbetween. 

This PR adds custom code to fix that shortcoming. I will also create a bug report for the factorio team, so hopefully we will have a better solution in the future.

Note: since the fix to splitters, we no longer care about if a build action is a fast-replace or not. 