### PR TITLE
Split tickhandler

### DIFF
--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -33,6 +33,7 @@ local duration = 0
 local ticks_mining = 0
 local idled = 0
 local font_size = 0.15 --best guess estimate of fontsize for flying text
+local q_save = nil
 
 local pos_pos = false
 local pos_neg = false
@@ -872,6 +873,11 @@ local function doStep(current_step)
 end
 
 local function handle_pretick()
+	if q_save and walking.walking == false and idle < 1 then 
+		save(q_save.task, q_save.name)
+		if steps[step] then warning(string.format("Creating safe save file for task %s resulted in saving on step %s", task, steps[step][1][1])) end
+		q_save = nil
+	end
 	--pretick sets step directly so it doesn't raise too many events
 	while run do
 		if steps[step] == nil then
@@ -883,7 +889,11 @@ local function handle_pretick()
 			speed(steps[step][3])
 			step = step + 1
 		elseif steps[step][2] == "save" then
-			save(steps[step][1][1], steps[step][3])
+			if walking.walking == false and idle < 1 then
+				save(steps[step][1][1], steps[step][3])
+			else
+				q_save = {task = steps[step][1][1], name = steps[step][3]}
+			end
 			step = step + 1
 		elseif steps[2] == "pick" then
 			pickup_ticks = pickup_ticks + steps[3] - 1

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -972,7 +972,7 @@ end
 --- handle end the run
 local function handle_posttick()
 	if not run then return end
-	if walking.walking or mining==0 or pickup_ticks==0 or idle==0 then --we have to finish the previous task before we end the run
+	if walking.walking or mining~=0 or pickup_ticks~=0 or idle~=0 then --we have to finish the previous task before we end the run
 	elseif steps[step] == nil or steps[step][1] == "break" then
 		msg(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))	
 		debug_state = false

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -872,23 +872,9 @@ local function doStep(current_step)
 end
 
 local function handle_pretick()
-	--pretick sets step directly so it doesn't raise to many events
+	--pretick sets step directly so it doesn't raise too many events
 	while run do
-		if steps[step] == nil or steps[step][1] == "break" then
-			msg(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))	
-			debug_state = false
-			run = false
-			return
-		elseif (steps[step][2] == "pause") then
-			pause()
-			msg("Script paused")
-			msg(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
-			debug_state = false
-			return
-		elseif (steps[step][2] == "stop") then
-			speed(steps[step][3])
-			msg(string.format("Script stopped - Game speed: %d", steps[step][3]))
-			msg(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
+		if steps[step] == nil then
 			debug_state = false
 			run = false
 			return
@@ -899,8 +885,8 @@ local function handle_pretick()
 		elseif steps[step][2] == "save" then
 			save(steps[step][1][1], steps[step][3])
 			step = step + 1
-		elseif current_step[2] == "pick" then
-			pickup_ticks = pickup_ticks + current_step[3] - 1
+		elseif steps[2] == "pick" then
+			pickup_ticks = pickup_ticks + steps[3] - 1
 			player.picking_state = true
 			change_step(1)
 		elseif(steps[step][2] == "walk" and walking.walking == false) then
@@ -983,8 +969,29 @@ local function handle_ontick()
 	end
 end
 
+--- handle end the run
 local function handle_posttick()
-	
+	if not run then return end
+	if walking.walking or mining==0 or pickup_ticks==0 or idle==0 then --we have to finish the previous task before we end the run
+	elseif steps[step] == nil or steps[step][1] == "break" then
+		msg(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))	
+		debug_state = false
+		run = false
+		return
+	elseif (steps[step][2] == "pause") then
+		pause()
+		msg("Script paused")
+		msg(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
+		debug_state = false
+		return
+	elseif (steps[step][2] == "stop") then
+		speed(steps[step][3])
+		msg(string.format("Script stopped - Game speed: %d", steps[step][3]))
+		msg(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
+		debug_state = false
+		run = false
+		return
+	end
 end
 
 -- Main per-tick event handler
@@ -1006,7 +1013,7 @@ script.on_event(defines.events.on_tick, function(event)
 
 	walking = walk()
 	handle_pretick()
-	if not run then return end --early end on from pretick
+	if not run then return end --early end from pretick
 
 	handle_ontick()
 

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -33,7 +33,7 @@ local duration = 0
 local ticks_mining = 0
 local idled = 0
 local font_size = 0.15 --best guess estimate of fontsize for flying text
-local q_save = nil
+local queued_save = nil
 
 local pos_pos = false
 local pos_neg = false
@@ -873,10 +873,10 @@ local function doStep(current_step)
 end
 
 local function handle_pretick()
-	if q_save and walking.walking == false and idle < 1 then 
-		save(q_save.task, q_save.name)
+	if queued_save and walking.walking == false and idle < 1 then 
+		save(queued_save.task, queued_save.name)
 		if steps[step] then warning(string.format("Creating safe save file for task %s resulted in saving on step %s", task, steps[step][1][1])) end
-		q_save = nil
+		queued_save = nil
 	end
 	--pretick sets step directly so it doesn't raise too many events
 	while run do
@@ -892,7 +892,7 @@ local function handle_pretick()
 			if walking.walking == false and idle < 1 then
 				save(steps[step][1][1], steps[step][3])
 			else
-				q_save = {task = steps[step][1][1], name = steps[step][3]}
+				queued_save = {task = steps[step][1][1], name = steps[step][3]}
 			end
 			step = step + 1
 		elseif steps[2] == "pick" then
@@ -970,7 +970,7 @@ local function handle_ontick()
 
 		end
 	else
-		if steps[step][2] ~= "walk" and steps[step][2] ~= "mine" and steps[step][2] ~= "idle" and steps[step][2] ~= "pick" then
+		if steps[step][2] ~= "walk" and steps[step][2] ~= "mine" and steps[step][2] ~= "idle" then
 			if doStep(steps[step]) then
 				-- Do step while walking
 				change_step(1)

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -672,6 +672,10 @@ local function pause()
 	return true
 end
 
+local function resume()
+	game.tick_paused = false
+end
+
 -- Set the gameplay speed. 1 is standard speed
 local function speed(speed)
 	game.speed = speed
@@ -899,6 +903,12 @@ local function handle_pretick()
 			pickup_ticks = pickup_ticks + steps[3] - 1
 			player.picking_state = true
 			change_step(1)
+		elseif (steps[step][2] == "pause") then
+			pause()
+			msg("Script paused")
+			msg(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
+			change_step(1)
+			debug_state = false
 		elseif(steps[step][2] == "walk" and walking.walking == false and idle < 1) then
 			use_old_walking_pattern = steps[step][4] == "old" --compatibility
 			if use_old_walking_pattern then return end --compatibility
@@ -987,12 +997,6 @@ local function handle_posttick()
 		msg(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))	
 		debug_state = false
 		run = false
-		return
-	elseif (steps[step][2] == "pause") then
-		pause()
-		msg("Script paused")
-		msg(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
-		debug_state = false
 		return
 	elseif (steps[step][2] == "stop") then
 		speed(steps[step][3])
@@ -1146,3 +1150,5 @@ script.on_init(function()
         if freeplay["set_disable_crashsite"] then remote.call("freeplay", "set_disable_crashsite", true) end --Disable crashsite
     end
 end)
+
+commands.add_command("resume", nil, resume)

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -904,8 +904,15 @@ local function handle_pretick()
 		elseif steps[step][2] == "save" then
 			save(steps[step][1][1], steps[step][3])
 			step = step + 1
-		elseif(steps[step][2] == "walk") then
+		elseif(steps[step][2] == "walk" and walking.walking == false) then
 			use_old_walking_pattern = steps[step][4] == "old" --compatibility
+			if use_old_walking_pattern then return end --compatibility
+
+			update_destination_position(steps[step][3][1], steps[step][3][2])
+
+			find_walking_pattern()
+			walking = walk()
+			step = step + 1
 		else
 			return --no more to do, break loop
 		end
@@ -998,10 +1005,10 @@ script.on_event(defines.events.on_tick, function(event)
 
 	update_player_position()
 
+	walking = walk()
 	handle_pretick()
 	if not run then return end --early end on from pretick
 
-	walking = walk()
 	handle_ontick()
 
 	handle_posttick()

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -877,7 +877,8 @@ local function doStep(current_step)
 end
 
 local function handle_pretick()
-	while true do
+	--pretick sets step directly so it doesn't raise to many events
+	while run do
 		if steps[step] == nil or steps[step][1] == "break" then
 			msg(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))	
 			debug_state = false

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -858,11 +858,6 @@ local function doStep(current_step)
 		drop_item = current_step[4]
 		return drop()
 
-	elseif current_step[2] == "pick" then
-		pickup_ticks = pickup_ticks + current_step[3] - 1
-		player.picking_state = true
-		return true
-
 	elseif current_step[2] == "idle" then
 		idle = current_step[3]
 		return true
@@ -904,6 +899,10 @@ local function handle_pretick()
 		elseif steps[step][2] == "save" then
 			save(steps[step][1][1], steps[step][3])
 			step = step + 1
+		elseif current_step[2] == "pick" then
+			pickup_ticks = pickup_ticks + current_step[3] - 1
+			player.picking_state = true
+			change_step(1)
 		elseif(steps[step][2] == "walk" and walking.walking == false) then
 			use_old_walking_pattern = steps[step][4] == "old" --compatibility
 			if use_old_walking_pattern then return end --compatibility
@@ -912,7 +911,7 @@ local function handle_pretick()
 
 			find_walking_pattern()
 			walking = walk()
-			step = step + 1
+			change_step(1)
 		else
 			return --no more to do, break loop
 		end

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -889,7 +889,7 @@ local function handle_pretick()
 			pickup_ticks = pickup_ticks + steps[3] - 1
 			player.picking_state = true
 			change_step(1)
-		elseif(steps[step][2] == "walk" and walking.walking == false) then
+		elseif(steps[step][2] == "walk" and walking.walking == false and idle < 1) then
 			use_old_walking_pattern = steps[step][4] == "old" --compatibility
 			if use_old_walking_pattern then return end --compatibility
 


### PR DESCRIPTION
Some formatting of control.lua
Splitted the tick handler.
Created a loop to handle steps that shouldn't cost a tick, so the order they appear in doens't matter.
Moved walking to the pre-tick. So start walking doesn't cost a tick.

Starting to walk before a task make sense, since walking is for the most part something you do while doing other task in a real speedrun.

Given how central a part of TAS handler this affects, i think we need a full test.