### PR TITLE
Refactor taskname to enum

### DIFF
--- a/src/OpenTas.cpp
+++ b/src/OpenTas.cpp
@@ -128,7 +128,7 @@ bool OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_progr
 		step.Direction = Capitalize(segments[6]);
 		step.Comment = comment;
 
-		step.TaskEnum = TaskNames.find(step.Task)->second;
+		step.TaskEnum = MapTaskNameToTaskType.find(step.Task)->second;
 
 		switch (step.TaskEnum)
 		{
@@ -251,7 +251,7 @@ bool OpenTas::extract_groups(std::ifstream& file, DialogProgressBar* dialog_prog
 		step.Direction = Capitalize(segments[7]);
 		step.Comment = comment;
 
-		step.TaskEnum = TaskNames.find(step.Task)->second;
+		step.TaskEnum = MapTaskNameToTaskType.find(step.Task)->second;
 
 		steps.push_back(step);
 
@@ -335,7 +335,7 @@ bool OpenTas::extract_templates(std::ifstream& file, DialogProgressBar* dialog_p
 		step.Direction = Capitalize(segments[7]);
 		step.Comment = comment;
 
-		step.TaskEnum = TaskNames.find(step.Task)->second;
+		step.TaskEnum = MapTaskNameToTaskType.find(step.Task)->second;
 
 		steps.push_back(step);
 

--- a/src/StepParameters.h
+++ b/src/StepParameters.h
@@ -24,7 +24,7 @@ struct StepParameters
 	int BuildingIndex;
 
 	Orientation OrientationIndex;
-	TaskName TaskEnum;
+	TaskType TaskEnum;
 
 	string Task;
 	string Amount;

--- a/src/TaskNameToEnum.cpp
+++ b/src/TaskNameToEnum.cpp
@@ -1,6 +1,6 @@
 #include "TaskNameToEnum.h"
 
-TaskName ToTaskName(string task)
+TaskType ToTaskType(string task)
 {
-	return TaskNames.find(task)->second;
+	return MapTaskNameToTaskType.find(task)->second;
 }

--- a/src/TaskNameToEnum.h
+++ b/src/TaskNameToEnum.h
@@ -6,13 +6,20 @@
 using std::map;
 using std::string;
 
-enum TaskName
+/// <summary>
+/// Enumaration of all task types
+/// </summary>
+enum TaskType
 {
 	e_start = 1, e_stop, e_build, e_craft, e_game_speed, e_pause, e_save, e_recipe, e_limit, e_filter, e_rotate, e_priority, e_put, e_take, e_mine, e_launch, e_walk, e_tech, e_drop, e_pick_up, e_idle
 };
 
 static const map<string, TaskName> TaskNames = {{"Start", e_start}, {"Stop", e_stop}, {"Build", e_build}, {"Craft", e_craft}, {"Game Speed", e_game_speed}, {"Pause", e_pause}, {"Save", e_save},
+/// <summary>
+/// Maps TaskName(string) to TaskType(enum)
+/// </summary>
+static const map<string, TaskType> MapTaskNameToTaskType = {{"Start", e_start}, {"Stop", e_stop}, {"Build", e_build}, {"Craft", e_craft}, {"Game Speed", e_game_speed}, {"Pause", e_pause}, {"Save", e_save},
 	{"Recipe", e_recipe}, {"Limit", e_limit}, {"Filter", e_filter}, {"Rotate", e_rotate}, {"Priority", e_priority}, {"Put", e_put}, {"Take", e_take}, {"Mine", e_mine}, {"Launch", e_launch},
 	{"Walk", e_walk}, {"Tech", e_tech}, {"Drop", e_drop}, {"Pick up", e_pick_up}, {"Idle", e_idle}};
 
-TaskName ToTaskName(string task);
+TaskType ToTaskType(string task);

--- a/src/TaskNameToEnum.h
+++ b/src/TaskNameToEnum.h
@@ -2,9 +2,11 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 using std::map;
 using std::string;
+using std::vector;
 
 /// <summary>
 /// Enumaration of all task types
@@ -14,7 +16,19 @@ enum TaskType
 	e_start = 1, e_stop, e_build, e_craft, e_game_speed, e_pause, e_save, e_recipe, e_limit, e_filter, e_rotate, e_priority, e_put, e_take, e_mine, e_launch, e_walk, e_tech, e_drop, e_pick_up, e_idle
 };
 
-static const map<string, TaskName> TaskNames = {{"Start", e_start}, {"Stop", e_stop}, {"Build", e_build}, {"Craft", e_craft}, {"Game Speed", e_game_speed}, {"Pause", e_pause}, {"Save", e_save},
+/// <summary>
+/// Contains every task name, aligned with TaskType
+/// </summary>
+/// <note>
+/// Starts with "None" for alignments
+/// </note>
+static const vector<string> TaskNames{
+	"None", 
+	"Start", "Stop", "Build", "Craft", "Game Speed", "Pause", "Save",
+	"Recipe", "Limit", "Filter", "Rotate", "Priority", "Put", "Take", "Mine", "Launch",
+	"Walk", "Tech", "Drop", "Pick up", "Idle"
+};
+
 /// <summary>
 /// Maps TaskName(string) to TaskType(enum)
 /// </summary>

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -255,7 +255,7 @@ void cMain::MoveRow(wxGrid* grid, bool up)
 
 			GridTransfer(grid, row, grid, moveTo);
 
-			BackgroundColorUpdate(grid, moveTo, ToTaskName(grid->GetCellValue(moveTo, 0).ToStdString()));
+			BackgroundColorUpdate(grid, moveTo, ToTaskType(grid->GetCellValue(moveTo, 0).ToStdString()));
 
 			grid->DeleteRows(row);
 
@@ -286,7 +286,7 @@ void cMain::MoveRow(wxGrid* grid, bool up)
 
 			grid->DeleteRows(row + 1);
 
-			BackgroundColorUpdate(grid, moveTo, ToTaskName(grid->GetCellValue(moveTo, 0).ToStdString()));
+			BackgroundColorUpdate(grid, moveTo, ToTaskType(grid->GetCellValue(moveTo, 0).ToStdString()));
 
 			auto it1 = StepGridData.begin();
 			it1 += row;
@@ -339,7 +339,7 @@ void cMain::GroupTemplateMoveRow(wxGrid* grid, wxComboBox* cmb, bool up, map<str
 
 		GridTransfer(grid, row, grid, rowNum + rowCount);
 
-		BackgroundColorUpdate(grid, rowNum + rowCount, ToTaskName(grid->GetCellValue(rowNum + rowCount, 0).ToStdString()));
+		BackgroundColorUpdate(grid, rowNum + rowCount, ToTaskType(grid->GetCellValue(rowNum + rowCount, 0).ToStdString()));
 
 		grid->DeleteRows(row);
 
@@ -456,7 +456,7 @@ bool cMain::ChangeRow(wxGrid* grid, StepParameters step)
 	return true;
 }
 
-void cMain::BackgroundColorUpdate(wxGrid* grid, int row, TaskName task)
+void cMain::BackgroundColorUpdate(wxGrid* grid, int row, TaskType task)
 {
 	switch (task)
 	{
@@ -1600,7 +1600,7 @@ void cMain::OnAddMenuSelected(wxCommandEvent& event)
 
 void cMain::UpdateParameters(GridEntry* gridEntry, wxCommandEvent& event)
 {
-	TaskName task = ToTaskName(gridEntry->Task.ToStdString());
+	TaskType task = ToTaskType(gridEntry->Task.ToStdString());
 
 	string orientation = "";
 	float speed;
@@ -1888,7 +1888,7 @@ StepParameters cMain::ExtractStepParameters()
 	stepParameters.PriorityOut = input_output[radio_output->GetSelection()];
 	stepParameters.Comment = txt_comment->GetValue().ToStdString();
 
-	stepParameters.TaskEnum = TaskNames.find(stepParameters.Task)->second;
+	stepParameters.TaskEnum = MapTaskNameToTaskType.find(stepParameters.Task)->second;
 
 	return stepParameters;
 }

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -231,7 +231,7 @@ private:
 	bool DeleteRow(wxGrid* grid, wxComboBox* cmb, map<string, vector<StepParameters>>& map);
 	bool ChangeRow(wxGrid* grid, StepParameters step);
 
-	void BackgroundColorUpdate(wxGrid* grid, int row, TaskName task);
+	void BackgroundColorUpdate(wxGrid* grid, int row, TaskType task);
 
 	void UpdateMapWithNewSteps(wxGrid* grid, wxComboBox* cmb, map<string, vector<StepParameters>>& map);
 	void UpdateGroupTemplateGrid(wxGrid* grid, vector<StepParameters>& steps);


### PR DESCRIPTION
Renamed TaskName to TaskType - mostly for my own sanity
Renamed TaskNames to MapTaskNameToTaskType - a bit verbose, but more accurate
Added summaries to both

Added a list of TaskNames for conversion enum:TaskType -> string:TaskName