### PR TITLE
prevent fallthrough on idle,gamespeed&pickup

### DIFF
--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1961,6 +1961,7 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 		case e_idle:
 		case e_pick_up:
 			gridEntry.Amount = stepParameters->Amount;
+			break;
 
 		case e_craft:
 			gridEntry.Amount = stepParameters->Amount;


### PR DESCRIPTION
To prevent item being included in idle commands