### PR TITLE
Improve save start

### DIFF
--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -932,11 +932,11 @@ local function doStep(current_step)
 end
 
 local function handle_pretick()
-	if queued_save and walking.walking == false and idle < 1 then 
+	if queued_save and walking.walking == false and idle < 1 and pickup_ticks < 1 then
 		save(queued_save.task, queued_save.name)
 
 		if steps[step] then
-			warning(string.format("Creating safe save file for step %s resulted in saving on step %s", task, steps[step][1][1])) 
+			warning(string.format("Creating safe save file for step %s resulted in saving on step %s", queued_save.task, steps[step][1][1])) 
 		end
 
 		queued_save = nil
@@ -952,14 +952,14 @@ local function handle_pretick()
 			speed(steps[step][3])
 			step = step + 1
 		elseif steps[step][2] == "save" then
-			if walking.walking == false and idle < 1 then
+			if walking.walking == false and idle < 1 and pickup_ticks < 1 then
 				save(steps[step][1][1], steps[step][3])
 			else
 				queued_save = {task = steps[step][1][1], name = steps[step][3]}
 			end
 			step = step + 1
-		elseif steps[2] == "pick" then
-			pickup_ticks = pickup_ticks + steps[3] - 1
+		elseif steps[step][2] == "pick" then
+			pickup_ticks = pickup_ticks + steps[step][3] - 1
 			player.picking_state = true
 			change_step(1)
 		elseif (steps[step][2] == "pause") then

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -33,6 +33,7 @@ local duration = 0
 local ticks_mining = 0
 local idled = 0
 local font_size = 0.15 --best guess estimate of fontsize for flying text
+local queued_save = nil
 
 local pos_pos = false
 local pos_neg = false
@@ -931,6 +932,15 @@ local function doStep(current_step)
 end
 
 local function handle_pretick()
+	if queued_save and walking.walking == false and idle < 1 then 
+		save(queued_save.task, queued_save.name)
+
+		if steps[step] then
+			warning(string.format("Creating safe save file for step %s resulted in saving on step %s", task, steps[step][1][1])) 
+		end
+
+		queued_save = nil
+	end
 	--pretick sets step directly so it doesn't raise too many events
 	while run do
 		if steps[step] == nil then
@@ -940,6 +950,13 @@ local function handle_pretick()
 		elseif (steps[step][2] == "speed") then
 			debug(string.format("Step: %s, Action: %s, Step: %s - Game speed: %d", steps[step][1][1], steps[step][1][2], step, steps[step][3]))
 			speed(steps[step][3])
+			step = step + 1
+		elseif steps[step][2] == "save" then
+			if walking.walking == false and idle < 1 then
+				save(steps[step][1][1], steps[step][3])
+			else
+				queued_save = {task = steps[step][1][1], name = steps[step][3]}
+			end
 			step = step + 1
 		elseif steps[2] == "pick" then
 			pickup_ticks = pickup_ticks + steps[3] - 1
@@ -964,17 +981,10 @@ local function handle_pretick()
 end
 
 local function handle_ontick()
-	if steps[step][2] == "save" then
-		save(steps[step][1][1], steps[step][3])
-		step = step + 1
-		return
-	end
-
 	if pickup_ticks > 0 then
 		player.picking_state = true
 		pickup_ticks = pickup_ticks - 1
 	end
-
 	if walking.walking == false then
 		if idle > 0 then
 			idle = idle - 1

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -80,6 +80,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 	dialog_progress_bar->Show();
 
 	const size_t amountOfSteps = steps.size();
+	int seek_start = 0;
 
 	string currentStep = "";
 	for (int i = 0; i < amountOfSteps; i++)
@@ -95,13 +96,14 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 		if (steps[i].StepEnum == e_start)
 		{
 			ClearSteps();
+			seek_start = 30;
 		}
 
 		if (steps[i].StepEnum == e_stop)
 		{
 			break;
 		}
-
+		
 		TransferParameters(steps[i]);
 		switch (steps[i].StepEnum)
 		{

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -51,6 +51,22 @@ void GenerateScript::AddInfoFile(string& folder_location)
 	saver.close();
 }
 
+int seek_start = 0;
+string save_walk = "";
+void inline GenerateScript::SeekStart(){
+	if (seek_start <= 0) 
+		return;
+	seek_start = 0;
+	if (save_walk != "")
+	{
+		total_steps = 2;
+		step_list = save_walk;
+		save_walk = "";
+	}
+	else
+		ClearSteps();
+}
+
 void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progress_bar, vector<StepParameters> steps, string& folder_location, bool auto_close, bool only_generate_script, string goal)
 {
 	reset();
@@ -80,12 +96,12 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 	dialog_progress_bar->Show();
 
 	const size_t amountOfSteps = steps.size();
-	int seek_start = 0;
 
 	string currentStep = "";
 	for (int i = 0; i < amountOfSteps; i++)
 	{
 		currentStep = std::to_string(i + 1);
+		seek_start--;
 
 		if (i > 0 && i % 25 == 0)
 		{
@@ -112,10 +128,20 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				break;
 
 			case e_walk:
+				if (seek_start > 1)
+				{
+					seek_start = 2;
+					ClearSteps();
+					walk(currentStep, "1", x_cord, y_cord, comment);
+					save_walk = step_list;
+					break;
+				}
+
 				walk(currentStep, "1", x_cord, y_cord, comment);
 				break;
 
 			case e_mine:
+				SeekStart();
 				if (amount == "All")
 				{
 					amount = "1000";
@@ -142,18 +168,22 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				rotate(currentStep, x_cord, y_cord, amount, item, build_orientation);
+				SeekStart();
 				break;
 
 			case e_craft:
 				craft(currentStep, amount == "All" ? "-1" : amount, item);
+				SeekStart();
 				break;
 
 			case e_tech:
 				tech(currentStep, item);
+				SeekStart();
 				break;
 
 			case e_build:
 				row_build(currentStep, x_cord, y_cord, item, build_orientation, direction_to_build, amount_of_buildings, building_size);
+				SeekStart();
 				break;
 
 			case e_take:
@@ -167,6 +197,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				}
 
 				row_take(currentStep, x_cord, y_cord, amount == "All" ? "-1" : amount, item, from_into, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
+				SeekStart();
 				break;
 
 			case e_put:
@@ -180,6 +211,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				}
 
 				row_put(currentStep, x_cord, y_cord, amount == "All" ? "-1" : amount, item, from_into, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
+				SeekStart();
 				break;
 
 			case e_recipe:
@@ -191,6 +223,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				row_recipe(currentStep, x_cord, y_cord, item, direction_to_build, building_size, amount_of_buildings, building, build_orientation);
+				SeekStart();
 				break;
 
 			case e_pause:
@@ -208,6 +241,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				}
 
 				row_limit(currentStep, x_cord, y_cord, amount, from_into, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
+				SeekStart();
 				break;
 
 			case e_priority:
@@ -226,6 +260,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 			SetBuildingAndOrientation(&steps[i]);
 
 			row_priority(currentStep, x_cord, y_cord, priority_in, priority_out, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
+			SeekStart();
 			break;
 
 			case e_filter:
@@ -237,6 +272,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				row_filter(currentStep, x_cord, y_cord, item, amount, check_input(building, splitter_list) ? "splitter" : "inserter", direction_to_build, amount_of_buildings, building_size, building, build_orientation);
+				SeekStart();
 				break;
 
 			case e_drop:
@@ -248,14 +284,17 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				row_drop(currentStep, x_cord, y_cord, item, direction_to_build, amount_of_buildings, building_size, building);
+				SeekStart();
 				break;
 
 			case e_pick_up:
+				SeekStart();
 				pick(currentStep, amount);
 				break;
 
 			case e_launch:
 				launch(currentStep, x_cord, y_cord);
+				SeekStart();
 				break;
 
 			case e_save:
@@ -263,6 +302,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				break;
 
 			case e_idle:
+				SeekStart();
 				idle(currentStep, amount);
 				break;
 		}

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -113,6 +113,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 		{
 			ClearSteps();
 			seek_start = 30;
+			continue;
 		}
 
 		if (steps[i].StepEnum == e_stop)
@@ -124,6 +125,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 		switch (steps[i].StepEnum)
 		{
 			case e_game_speed:
+				seek_start++;
 				speed(currentStep, amount);
 				break;
 
@@ -172,6 +174,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				break;
 
 			case e_craft:
+				seek_start++;
 				craft(currentStep, amount == "All" ? "-1" : amount, item);
 				SeekStart();
 				break;
@@ -197,7 +200,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				}
 
 				row_take(currentStep, x_cord, y_cord, amount == "All" ? "-1" : amount, item, from_into, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
-				SeekStart();
 				break;
 
 			case e_put:
@@ -211,7 +213,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				}
 
 				row_put(currentStep, x_cord, y_cord, amount == "All" ? "-1" : amount, item, from_into, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
-				SeekStart();
 				break;
 
 			case e_recipe:
@@ -223,10 +224,10 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				row_recipe(currentStep, x_cord, y_cord, item, direction_to_build, building_size, amount_of_buildings, building, build_orientation);
-				SeekStart();
 				break;
 
 			case e_pause:
+				seek_start++;
 				pause(currentStep);
 				break;
 
@@ -241,7 +242,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				}
 
 				row_limit(currentStep, x_cord, y_cord, amount, from_into, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
-				SeekStart();
 				break;
 
 			case e_priority:
@@ -260,7 +260,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 			SetBuildingAndOrientation(&steps[i]);
 
 			row_priority(currentStep, x_cord, y_cord, priority_in, priority_out, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
-			SeekStart();
 			break;
 
 			case e_filter:
@@ -272,7 +271,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				row_filter(currentStep, x_cord, y_cord, item, amount, check_input(building, splitter_list) ? "splitter" : "inserter", direction_to_build, amount_of_buildings, building_size, building, build_orientation);
-				SeekStart();
 				break;
 
 			case e_drop:
@@ -284,7 +282,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				row_drop(currentStep, x_cord, y_cord, item, direction_to_build, amount_of_buildings, building_size, building);
-				SeekStart();
 				break;
 
 			case e_pick_up:
@@ -298,6 +295,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				break;
 
 			case e_save:
+				seek_start++;
 				save(currentStep, comment);
 				break;
 
@@ -1070,7 +1068,7 @@ void GenerateScript::row_take(string step, string x_cord, string y_cord, string 
 {
 
 	take(step, "1", x_cord, y_cord, amount, item, from, building, OrientationEnum);
-
+	SeekStart();
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1099,6 +1097,7 @@ void GenerateScript::put(string step, string action, string x_cord, string y_cor
 void GenerateScript::row_put(string step, string x_cord, string y_cord, string amount, string item, string from, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum)
 {
 	put(step, "1", x_cord, y_cord, amount, item, from, building, OrientationEnum);
+	SeekStart();
 
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
@@ -1122,7 +1121,7 @@ void GenerateScript::row_recipe(string step, string x_cord, string y_cord, strin
 {
 
 	recipe(step, "1", x_cord, y_cord, item, building, OrientationEnum);
-
+	SeekStart();
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1142,7 +1141,7 @@ void GenerateScript::limit(string step, string action, string x_cord, string y_c
 void GenerateScript::row_limit(string step, string x_cord, string y_cord, string amount, string from, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum)
 {
 	limit(step, "1", x_cord, y_cord, amount, from, building, OrientationEnum);
-
+	SeekStart();
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1165,7 +1164,7 @@ void GenerateScript::row_priority(string step, string x_cord, string y_cord, str
 	priority_out = convert_string(priority_out);
 
 	priority(step, "1", x_cord, y_cord, priority_in, priority_out, building, OrientationEnum);
-
+	SeekStart();
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1187,7 +1186,7 @@ void GenerateScript::filter(string step, string action, string x_cord, string y_
 void GenerateScript::row_filter(string step, string x_cord, string y_cord, string item, string amount, string type, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum)
 {
 	filter(step, "1", x_cord, y_cord, item, amount, type, building, OrientationEnum);
-
+	SeekStart();
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1209,7 +1208,7 @@ void GenerateScript::drop(string step, string action, string x_cord, string y_co
 void GenerateScript::row_drop(string step, string x_cord, string y_cord, string item, string direction, string number_of_buildings, string building_size, string building)
 {
 	drop(step, "1", x_cord, y_cord, item, building);
-
+	SeekStart();
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -259,34 +259,8 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				break;
 
 			case e_save:
-				if (i != 0 && i + 1 != amountOfSteps && last_walking_comment != "old")
-				{
-					// A save should be between two walk steps
-					if (steps[i - 1].StepEnum == e_walk && steps[i + 1].StepEnum == e_walk)
-					{
-						// The character should be running straight to ensure that the character doesn't start walking incorectly when the save is loaded.
-						if (steps[i - 1].X == steps[i + 1].X || steps[i - 1].Y == steps[i + 1].Y)
-						{
-							save(currentStep, comment);
-							break;
-						}
-					}
-
-					// Or the next step after the save needs to be a start step and the next after that should be a walk
-					if (i + 2 != amountOfSteps && steps[i + 1].StepEnum == e_start || steps[i + 2].StepEnum == e_walk)
-					{
-						// The character should be running straight to ensure that the character doesn't start walking incorectly when the save is loaded.
-						if (steps[i - 1].X == steps[i + 2].X || steps[i - 1].Y == steps[i + 2].Y)
-						{
-							save(currentStep, comment);
-							break;
-						}
-					}
-				}
-
-				wxMessageBox("A save step should be between two walk steps and the character has to be running straight (either X or Y of both walk steps should be same)", "Invalid Save", wxICON_WARNING);
-				dialog_progress_bar->Close();
-				return;
+				save(currentStep, comment);
+				break;
 
 			case e_idle:
 				idle(currentStep, amount);

--- a/src/GenerateScript.h
+++ b/src/GenerateScript.h
@@ -25,6 +25,7 @@ class GenerateScript
 {
 public:
 	GenerateScript();
+	void SeekStart();
 	void generate(wxWindow* parent, DialogProgressBar* dialog_progress_bar, vector<StepParameters> steps, string& folder_location, bool auto_close, bool only_generate_script, string goal);
 
 private:

--- a/src/OpenTas.cpp
+++ b/src/OpenTas.cpp
@@ -128,7 +128,11 @@ bool OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_progr
 		step.Direction = Capitalize(segments[6]);
 		step.Comment = comment;
 
-		step.StepEnum = MapStepNameToStepType.find(step.Step)->second;
+		auto mappedtype = MapStepNameToStepType.find(step.Step);
+		if (mappedtype == MapStepNameToStepType.end()) 
+			return false;
+
+		step.StepEnum = mappedtype->second;
 
 		switch (step.StepEnum)
 		{
@@ -220,7 +224,7 @@ bool OpenTas::extract_groups(std::ifstream& file, DialogProgressBar* dialog_prog
 		}
 
 		string comment = "";
-		if (segments.size() != group_segment_size)
+		if (segments.size() == group_segment_size)
 		{
 			comment = segments[10];
 		}
@@ -245,7 +249,7 @@ bool OpenTas::extract_groups(std::ifstream& file, DialogProgressBar* dialog_prog
 			step.Buildings = stoi(segments[9]);
 		}
 
-		step.Step = Capitalize(segments[1]);
+		step.Step = Capitalize(segments[0]);
 		step.Amount = Capitalize(segments[4]);
 		step.Item = Capitalize(segments[5], true);
 		step.Orientation = Capitalize(segments[6]);

--- a/src/OpenTas.cpp
+++ b/src/OpenTas.cpp
@@ -249,14 +249,17 @@ bool OpenTas::extract_groups(std::ifstream& file, DialogProgressBar* dialog_prog
 			step.Buildings = stoi(segments[9]);
 		}
 
-		step.Step = Capitalize(segments[0]);
+		step.Step = Capitalize(segments[1]);
 		step.Amount = Capitalize(segments[4]);
 		step.Item = Capitalize(segments[5], true);
 		step.Orientation = Capitalize(segments[6]);
 		step.Direction = Capitalize(segments[7]);
 		step.Comment = comment;
 
-		step.StepEnum = MapStepNameToStepType.find(step.Step)->second;
+		auto mappedtype = MapStepNameToStepType.find(step.Step);
+		if (mappedtype == MapStepNameToStepType.end())
+			return false;
+		step.StepEnum = mappedtype->second;
 
 		steps.push_back(step);
 

--- a/src/OpenTas.cpp
+++ b/src/OpenTas.cpp
@@ -311,7 +311,7 @@ bool OpenTas::extract_templates(std::ifstream& file, DialogProgressBar* dialog_p
 		}
 
 		string comment = "";
-		if (segments.size() != group_segment_size)
+		if (segments.size() == group_segment_size)
 		{
 			comment = segments[10];
 		}

--- a/src/StepNameToEnum.h
+++ b/src/StepNameToEnum.h
@@ -32,7 +32,7 @@ static const vector<string> StepNames{
 /// <summary>
 /// Maps StepName(string) to StepType(enum)
 /// </summary>
-static const map<string, StepType> MapStepNameToStepType = {{"Start", e_start}, {"Stop", e_stop}, {"Build", e_build}, {"Craft", e_craft}, {"Game Speed", e_game_speed}, {"Pause", e_pause}, {"Save", e_save},
+static const map<string, StepType> MapStepNameToStepType = {{"Start", e_start}, {"Stop", e_stop}, {"Build", e_build}, {"Craft", e_craft}, {"Game speed", e_game_speed}, {"Pause", e_pause}, {"Save", e_save},
 	{"Recipe", e_recipe}, {"Limit", e_limit}, {"Filter", e_filter}, {"Rotate", e_rotate}, {"Priority", e_priority}, {"Put", e_put}, {"Take", e_take}, {"Mine", e_mine}, {"Launch", e_launch},
 	{"Walk", e_walk}, {"Tech", e_tech}, {"Drop", e_drop}, {"Pick up", e_pick_up}, {"Idle", e_idle}};
 


### PR DESCRIPTION
**Reverted change save** as it didn't appear to work

Fixed some problems with reading the pickup step
Added pickup to save blocking for safe saves
Fixed a problem with opening a tas file with _game speed_
Fixed some problems with opening with tas file with groups

**Added seekstart** to GenerateScript::generate
Which moves the starting point to a better point, than what the user might have chosen. Using up to 30 tries (was should be enough) to a good point.
It places the start after the next on-tick task or before the next walk task.
Except it also erases the next on-tick task if it is after a starting walk task.