### PR TITLE
Move save start to lua

### DIFF
--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -41,7 +41,7 @@ local neg_neg
 local compatibility_mode
 local keep_x
 local keep_y
-local diagonal = false
+local diagonal
 
 local drop_item
 local drop_position
@@ -674,7 +674,7 @@ local function walk()
 	if compatibility_mode then
 		return {walking = false, direction = defines.direction.north}
 	else
-		return {walking = false, direction = defines.direction.north}
+		return {walking = false, direction = walking.direction}
 	end
 end
 
@@ -1407,6 +1407,7 @@ local function create_tas_global_state()
 		duration = 0,
 		ticks_mining = 0,
 		idled = 0,
+		diagonal = false,
 	}
 	
 end

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -33,6 +33,7 @@ local duration = 0
 local ticks_mining = 0
 local idled = 0
 local font_size = 0.15 --best guess estimate of fontsize for flying text
+local queued_save = nil
 
 local pos_pos = false
 local pos_neg = false
@@ -969,6 +970,15 @@ local function doStep(current_step)
 end
 
 local function handle_pretick()
+	if queued_save and walking.walking == false and idle < 1 then 
+		save(queued_save.task, queued_save.name)
+
+		if steps[step] then
+			warning(string.format("Creating safe save file for step %s resulted in saving on step %s", task, steps[step][1][1])) 
+		end
+
+		queued_save = nil
+	end
 	--pretick sets step directly so it doesn't raise too many events
 	while run do
 		if steps[step] == nil then
@@ -978,6 +988,13 @@ local function handle_pretick()
 		elseif (steps[step][2] == "speed") then
 			debug(string.format("Step: %s, Action: %s, Step: %s - Game speed: %d", steps[step][1][1], steps[step][1][2], step, steps[step][3]))
 			speed(steps[step][3])
+			step = step + 1
+		elseif steps[step][2] == "save" then
+			if walking.walking == false and idle < 1 then
+				save(steps[step][1][1], steps[step][3])
+			else
+				queued_save = {task = steps[step][1][1], name = steps[step][3]}
+			end
 			step = step + 1
 		elseif steps[2] == "pick" then
 			pickup_ticks = pickup_ticks + steps[3] - 1
@@ -1002,17 +1019,10 @@ local function handle_pretick()
 end
 
 local function handle_ontick()
-	if steps[step][2] == "save" then
-		save(steps[step][1][1], steps[step][3])
-		step = step + 1
-		return
-	end
-
 	if pickup_ticks > 0 then
 		player.picking_state = true
 		pickup_ticks = pickup_ticks - 1
 	end
-
 	if walking.walking == false then
 		if idle > 0 then
 			idle = idle - 1

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -970,11 +970,11 @@ local function doStep(current_step)
 end
 
 local function handle_pretick()
-	if queued_save and walking.walking == false and idle < 1 then 
+	if queued_save and walking.walking == false and idle < 1 and pickup_ticks < 1 then
 		save(queued_save.task, queued_save.name)
 
 		if steps[step] then
-			warning(string.format("Creating safe save file for step %s resulted in saving on step %s", task, steps[step][1][1])) 
+			warning(string.format("Creating safe save file for step %s resulted in saving on step %s", queued_save.task, steps[step][1][1])) 
 		end
 
 		queued_save = nil
@@ -990,14 +990,14 @@ local function handle_pretick()
 			speed(steps[step][3])
 			step = step + 1
 		elseif steps[step][2] == "save" then
-			if walking.walking == false and idle < 1 then
+			if walking.walking == false and idle < 1 and pickup_ticks < 1 then
 				save(steps[step][1][1], steps[step][3])
 			else
 				queued_save = {task = steps[step][1][1], name = steps[step][3]}
 			end
 			step = step + 1
-		elseif steps[2] == "pick" then
-			pickup_ticks = pickup_ticks + steps[3] - 1
+		elseif steps[step][2] == "pick" then
+			pickup_ticks = pickup_ticks + steps[step][3] - 1
 			player.picking_state = true
 			change_step(1)
 		elseif (steps[step][2] == "pause") then

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -5,11 +5,11 @@ local steps = require("steps")
 local debug_state = require("goal")
 local run = true
 
-local step = 1
+local step
 local step_reached = 0
-local idle = 0
-local pickup_ticks = 0
-local mining = 0
+local idle
+local pickup_ticks
+local mining
 
 local player
 local player_selection
@@ -29,24 +29,62 @@ local input
 local output
 local type
 local rev
-local duration = 0
-local ticks_mining = 0
-local idled = 0
+local duration
+local ticks_mining
+local idled
 local font_size = 0.15 --best guess estimate of fontsize for flying text
 
-local pos_pos = false
-local pos_neg = false
-local neg_pos = false
-local neg_neg = false
-local compatibility_mode = false
-local keep_x = false
-local keep_y = false
+local pos_pos
+local pos_neg
+local neg_pos
+local neg_neg
+local compatibility_mode
+local keep_x
+local keep_y
 local diagonal = false
 
 local drop_item
 local drop_position
 
+local queued_save
 local tas_step_change = script.generate_event_name()
+
+local function save_global()
+	--if not global.tas then return end
+	global.tas.step = step
+	global.tas.idle = idle
+	global.tas.pickup_ticks = pickup_ticks
+	global.tas.mining = mining
+	global.tas.pos_pos = pos_pos
+	global.tas.pos_neg = pos_neg
+	global.tas.neg_pos = neg_pos
+	global.tas.neg_neg = neg_neg
+	global.tas.compatibility_mode = compatibility_mode
+	global.tas.keep_x = keep_x
+	global.tas.keep_y = keep_y
+	global.tas.player_selection = player_selection
+	global.tas.destination = destination
+	global.tas.target_position = target_position
+	global.tas.target_inventory = target_inventory
+	global.tas.walking = walking
+	global.tas.task = task
+	global.tas.task_category = task_category
+	global.tas.count = count
+	global.tas.item = item
+	global.tas.amount = amount
+	global.tas.slot = slot
+	global.tas.direction = direction
+	global.tas.input = input
+	global.tas.output = output
+	global.tas.type = type
+	global.tas.rev = rev
+	global.tas.duration = duration
+	global.tas.ticks_mining = ticks_mining
+	global.tas.idled = idled
+	global.tas.diagonal = diagonal
+
+	global.tas.player = player
+end
 
 --recreate crash site
 local on_player_created = function(event)
@@ -102,6 +140,7 @@ local function change_step(by)
 end
 
 local function save(task, nameOfSaveGame)
+	save_global()
 	if game.is_multiplayer() then
 		debug(string.format("Step: %s, saving game as %s", task, nameOfSaveGame))
 		game.server_save(nameOfSaveGame)
@@ -635,7 +674,7 @@ local function walk()
 	if compatibility_mode then
 		return {walking = false, direction = defines.direction.north}
 	else
-		return {walking = false, direction = walking.direction}
+		return {walking = false, direction = defines.direction.north}
 	end
 end
 
@@ -980,7 +1019,7 @@ local function handle_pretick()
 			speed(steps[step][3])
 			step = step + 1
 		elseif steps[step][2] == "save" then
-			save(steps[step][1][1], steps[step][3])
+			queued_save = {name = steps[step][1][1], step = steps[step][3]}
 			step = step + 1
 		elseif steps[step][2] == "pick" then
 			pickup_ticks = pickup_ticks + steps[step][3] - 1
@@ -1082,6 +1121,11 @@ end
 local function handle_posttick()
 	if not run then
 		return
+	end
+
+	if queued_save then
+		save(queued_save.name, queued_save.step)
+		queued_save = nil
 	end
 
 	if walking.walking or mining~=0 or pickup_ticks~=0 or idle~=0 then
@@ -1347,14 +1391,77 @@ script.on_event(defines.events.on_player_created, function(event)
 	on_player_created(event)
 end)
 
+local function create_tas_global_state()
+	global.tas = {
+		step = 1,
+		idle = 0,
+		pickup_ticks = 0,
+		mining = 0,
+		pos_pos = false,
+		pos_neg = false,
+		neg_pos = false,
+ 		neg_neg = false,
+ 		compatibility_mode = false,
+ 		keep_x = false,
+ 		keep_y = false,
+		duration = 0,
+		ticks_mining = 0,
+		idled = 0,
+	}
+	
+end
+
+local function migrate_global()
+	if not global.tas then return end
+	step = global.tas.step
+	idle = global.tas.idle
+	pickup_ticks = global.tas.pickup_ticks
+	mining = global.tas.mining
+	pos_pos = global.tas.pos_pos
+	pos_neg = global.tas.pos_neg
+	neg_pos = global.tas.neg_pos
+	neg_neg = global.tas.neg_neg
+	diagonal = global.tas.diagonal
+	compatibility_mode = global.tas.compatibility_mode
+	keep_x = global.tas.keep_x
+	keep_y = global.tas.keep_y
+	player_selection = global.tas.player_selection
+	destination = global.tas.destination
+	target_position = global.tas.target_position
+	target_inventory = global.tas.target_inventory
+	walking = global.tas.walking
+	task = global.tas.task
+	task_category = global.tas.task_category
+	count = global.tas.count
+	item = global.tas.item
+	amount = global.tas.amount
+	slot = global.tas.slot
+	direction = global.tas.direction
+	input = global.tas.input
+	output = global.tas.output
+	type = global.tas.type
+	rev = global.tas.rev
+	duration = global.tas.duration
+	ticks_mining = global.tas.ticks_mining
+	idled = global.tas.idled
+
+	player = global.tas.player
+	if player then
+		player_position = player.position
+	end
+end
 
 script.on_init(function()
-    local freeplay = remote.interfaces["freeplay"]
+    local freeplay = remote.interfaces["freeplay"] --Setup tas interface
     if freeplay then
 		if freeplay["set_skip_intro"] then remote.call("freeplay", "set_skip_intro", true) end -- Disable freeplay popup-message
         if freeplay["set_disable_crashsite"] then remote.call("freeplay", "set_disable_crashsite", true) end --Disable crashsite
     end
+	create_tas_global_state()
+	migrate_global()
 end)
+
+script.on_load(migrate_global)
 
 script.on_event(defines.events.on_console_chat, function(event)
 	if event.message then

--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -33,7 +33,6 @@ local duration = 0
 local ticks_mining = 0
 local idled = 0
 local font_size = 0.15 --best guess estimate of fontsize for flying text
-local queued_save = nil
 
 local pos_pos = false
 local pos_neg = false
@@ -970,15 +969,6 @@ local function doStep(current_step)
 end
 
 local function handle_pretick()
-	if queued_save and walking.walking == false and idle < 1 and pickup_ticks < 1 then
-		save(queued_save.task, queued_save.name)
-
-		if steps[step] then
-			warning(string.format("Creating safe save file for step %s resulted in saving on step %s", queued_save.task, steps[step][1][1])) 
-		end
-
-		queued_save = nil
-	end
 	--pretick sets step directly so it doesn't raise too many events
 	while run do
 		if steps[step] == nil then
@@ -990,11 +980,7 @@ local function handle_pretick()
 			speed(steps[step][3])
 			step = step + 1
 		elseif steps[step][2] == "save" then
-			if walking.walking == false and idle < 1 and pickup_ticks < 1 then
-				save(steps[step][1][1], steps[step][3])
-			else
-				queued_save = {task = steps[step][1][1], name = steps[step][3]}
-			end
+			save(steps[step][1][1], steps[step][3])
 			step = step + 1
 		elseif steps[step][2] == "pick" then
 			pickup_ticks = pickup_ticks + steps[step][3] - 1

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -80,6 +80,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 	dialog_progress_bar->Show();
 
 	const size_t amountOfSteps = steps.size();
+	int seek_start = 0;
 
 	string currentStep = "";
 	for (int i = 0; i < amountOfSteps; i++)
@@ -95,13 +96,14 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 		if (steps[i].StepEnum == e_start)
 		{
 			ClearSteps();
+			seek_start = 30;
 		}
 
 		if (steps[i].StepEnum == e_stop)
 		{
 			break;
 		}
-
+		
 		TransferParameters(steps[i]);
 		switch (steps[i].StepEnum)
 		{

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -51,6 +51,22 @@ void GenerateScript::AddInfoFile(string& folder_location)
 	saver.close();
 }
 
+int seek_start = 0;
+string save_walk = "";
+void inline GenerateScript::SeekStart(){
+	if (seek_start <= 0) 
+		return;
+	seek_start = 0;
+	if (save_walk != "")
+	{
+		total_steps = 2;
+		step_list = save_walk;
+		save_walk = "";
+	}
+	else
+		ClearSteps();
+}
+
 void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progress_bar, vector<StepParameters> steps, string& folder_location, bool auto_close, bool only_generate_script, string goal)
 {
 	reset();
@@ -80,12 +96,12 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 	dialog_progress_bar->Show();
 
 	const size_t amountOfSteps = steps.size();
-	int seek_start = 0;
 
 	string currentStep = "";
 	for (int i = 0; i < amountOfSteps; i++)
 	{
 		currentStep = std::to_string(i + 1);
+		seek_start--;
 
 		if (i > 0 && i % 25 == 0)
 		{
@@ -112,10 +128,20 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				break;
 
 			case e_walk:
+				if (seek_start > 1)
+				{
+					seek_start = 2;
+					ClearSteps();
+					walk(currentStep, "1", x_cord, y_cord, comment);
+					save_walk = step_list;
+					break;
+				}
+
 				walk(currentStep, "1", x_cord, y_cord, comment);
 				break;
 
 			case e_mine:
+				SeekStart();
 				if (amount == "All")
 				{
 					amount = "1000";
@@ -142,18 +168,22 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				rotate(currentStep, x_cord, y_cord, amount, item, build_orientation);
+				SeekStart();
 				break;
 
 			case e_craft:
 				craft(currentStep, amount == "All" ? "-1" : amount, item);
+				SeekStart();
 				break;
 
 			case e_tech:
 				tech(currentStep, item);
+				SeekStart();
 				break;
 
 			case e_build:
 				row_build(currentStep, x_cord, y_cord, item, build_orientation, direction_to_build, amount_of_buildings, building_size);
+				SeekStart();
 				break;
 
 			case e_take:
@@ -167,6 +197,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				}
 
 				row_take(currentStep, x_cord, y_cord, amount == "All" ? "-1" : amount, item, from_into, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
+				SeekStart();
 				break;
 
 			case e_put:
@@ -180,6 +211,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				}
 
 				row_put(currentStep, x_cord, y_cord, amount == "All" ? "-1" : amount, item, from_into, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
+				SeekStart();
 				break;
 
 			case e_recipe:
@@ -191,6 +223,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				row_recipe(currentStep, x_cord, y_cord, item, direction_to_build, building_size, amount_of_buildings, building, build_orientation);
+				SeekStart();
 				break;
 
 			case e_pause:
@@ -208,6 +241,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				}
 
 				row_limit(currentStep, x_cord, y_cord, amount, from_into, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
+				SeekStart();
 				break;
 
 			case e_priority:
@@ -226,6 +260,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 			SetBuildingAndOrientation(&steps[i]);
 
 			row_priority(currentStep, x_cord, y_cord, priority_in, priority_out, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
+			SeekStart();
 			break;
 
 			case e_filter:
@@ -237,6 +272,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				row_filter(currentStep, x_cord, y_cord, item, amount, check_input(building, splitter_list) ? "splitter" : "inserter", direction_to_build, amount_of_buildings, building_size, building, build_orientation);
+				SeekStart();
 				break;
 
 			case e_drop:
@@ -248,14 +284,17 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				row_drop(currentStep, x_cord, y_cord, item, direction_to_build, amount_of_buildings, building_size, building);
+				SeekStart();
 				break;
 
 			case e_pick_up:
+				SeekStart();
 				pick(currentStep, amount);
 				break;
 
 			case e_launch:
 				launch(currentStep, x_cord, y_cord);
+				SeekStart();
 				break;
 
 			case e_save:
@@ -263,6 +302,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				break;
 
 			case e_idle:
+				SeekStart();
 				idle(currentStep, amount);
 				break;
 		}

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -51,22 +51,6 @@ void GenerateScript::AddInfoFile(string& folder_location)
 	saver.close();
 }
 
-int seek_start = 0;
-string save_walk = "";
-void inline GenerateScript::SeekStart(){
-	if (seek_start <= 0) 
-		return;
-	seek_start = 0;
-	if (save_walk != "")
-	{
-		total_steps = 2;
-		step_list = save_walk;
-		save_walk = "";
-	}
-	else
-		ClearSteps();
-}
-
 void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progress_bar, vector<StepParameters> steps, string& folder_location, bool auto_close, bool only_generate_script, string goal)
 {
 	reset();
@@ -101,7 +85,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 	for (int i = 0; i < amountOfSteps; i++)
 	{
 		currentStep = std::to_string(i + 1);
-		seek_start--;
 
 		if (i > 0 && i % 25 == 0)
 		{
@@ -112,7 +95,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 		if (steps[i].StepEnum == e_start)
 		{
 			ClearSteps();
-			seek_start = 30;
 			continue;
 		}
 
@@ -125,25 +107,14 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 		switch (steps[i].StepEnum)
 		{
 			case e_game_speed:
-				seek_start++;
 				speed(currentStep, amount);
 				break;
 
 			case e_walk:
-				if (seek_start > 1)
-				{
-					seek_start = 2;
-					ClearSteps();
-					walk(currentStep, "1", x_cord, y_cord, comment);
-					save_walk = step_list;
-					break;
-				}
-
 				walk(currentStep, "1", x_cord, y_cord, comment);
 				break;
 
 			case e_mine:
-				SeekStart();
 				if (amount == "All")
 				{
 					amount = "1000";
@@ -170,23 +141,18 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				rotate(currentStep, x_cord, y_cord, amount, item, build_orientation);
-				SeekStart();
 				break;
 
 			case e_craft:
-				seek_start++;
 				craft(currentStep, amount == "All" ? "-1" : amount, item);
-				SeekStart();
 				break;
 
 			case e_tech:
 				tech(currentStep, item);
-				SeekStart();
 				break;
 
 			case e_build:
 				row_build(currentStep, x_cord, y_cord, item, build_orientation, direction_to_build, amount_of_buildings, building_size);
-				SeekStart();
 				break;
 
 			case e_take:
@@ -227,7 +193,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				break;
 
 			case e_pause:
-				seek_start++;
 				pause(currentStep);
 				break;
 
@@ -285,22 +250,18 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				break;
 
 			case e_pick_up:
-				SeekStart();
 				pick(currentStep, amount);
 				break;
 
 			case e_launch:
 				launch(currentStep, x_cord, y_cord);
-				SeekStart();
 				break;
 
 			case e_save:
-				seek_start++;
 				save(currentStep, comment);
 				break;
 
 			case e_idle:
-				SeekStart();
 				idle(currentStep, amount);
 				break;
 		}
@@ -1072,9 +1033,8 @@ void GenerateScript::take(string step, string action, string x_cord, string y_co
 
 void GenerateScript::row_take(string step, string x_cord, string y_cord, string amount, string item, string from, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum)
 {
-
 	take(step, "1", x_cord, y_cord, amount, item, from, building, OrientationEnum);
-	SeekStart();
+
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1103,7 +1063,6 @@ void GenerateScript::put(string step, string action, string x_cord, string y_cor
 void GenerateScript::row_put(string step, string x_cord, string y_cord, string amount, string item, string from, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum)
 {
 	put(step, "1", x_cord, y_cord, amount, item, from, building, OrientationEnum);
-	SeekStart();
 
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
@@ -1125,9 +1084,8 @@ void GenerateScript::recipe(string step, string action, string x_cord, string y_
 
 void GenerateScript::row_recipe(string step, string x_cord, string y_cord, string item, string direction, string building_size, string number_of_buildings, string building, string OrientationEnum)
 {
-
 	recipe(step, "1", x_cord, y_cord, item, building, OrientationEnum);
-	SeekStart();
+
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1147,7 +1105,7 @@ void GenerateScript::limit(string step, string action, string x_cord, string y_c
 void GenerateScript::row_limit(string step, string x_cord, string y_cord, string amount, string from, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum)
 {
 	limit(step, "1", x_cord, y_cord, amount, from, building, OrientationEnum);
-	SeekStart();
+
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1170,7 +1128,7 @@ void GenerateScript::row_priority(string step, string x_cord, string y_cord, str
 	priority_out = convert_string(priority_out);
 
 	priority(step, "1", x_cord, y_cord, priority_in, priority_out, building, OrientationEnum);
-	SeekStart();
+
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1192,7 +1150,7 @@ void GenerateScript::filter(string step, string action, string x_cord, string y_
 void GenerateScript::row_filter(string step, string x_cord, string y_cord, string item, string amount, string type, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum)
 {
 	filter(step, "1", x_cord, y_cord, item, amount, type, building, OrientationEnum);
-	SeekStart();
+
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1214,7 +1172,7 @@ void GenerateScript::drop(string step, string action, string x_cord, string y_co
 void GenerateScript::row_drop(string step, string x_cord, string y_cord, string item, string direction, string number_of_buildings, string building_size, string building)
 {
 	drop(step, "1", x_cord, y_cord, item, building);
-	SeekStart();
+
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -113,6 +113,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 		{
 			ClearSteps();
 			seek_start = 30;
+			continue;
 		}
 
 		if (steps[i].StepEnum == e_stop)
@@ -124,6 +125,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 		switch (steps[i].StepEnum)
 		{
 			case e_game_speed:
+				seek_start++;
 				speed(currentStep, amount);
 				break;
 
@@ -172,6 +174,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				break;
 
 			case e_craft:
+				seek_start++;
 				craft(currentStep, amount == "All" ? "-1" : amount, item);
 				SeekStart();
 				break;
@@ -197,7 +200,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				}
 
 				row_take(currentStep, x_cord, y_cord, amount == "All" ? "-1" : amount, item, from_into, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
-				SeekStart();
 				break;
 
 			case e_put:
@@ -211,7 +213,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				}
 
 				row_put(currentStep, x_cord, y_cord, amount == "All" ? "-1" : amount, item, from_into, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
-				SeekStart();
 				break;
 
 			case e_recipe:
@@ -223,10 +224,10 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				row_recipe(currentStep, x_cord, y_cord, item, direction_to_build, building_size, amount_of_buildings, building, build_orientation);
-				SeekStart();
 				break;
 
 			case e_pause:
+				seek_start++;
 				pause(currentStep);
 				break;
 
@@ -241,7 +242,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				}
 
 				row_limit(currentStep, x_cord, y_cord, amount, from_into, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
-				SeekStart();
 				break;
 
 			case e_priority:
@@ -260,7 +260,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 			SetBuildingAndOrientation(&steps[i]);
 
 			row_priority(currentStep, x_cord, y_cord, priority_in, priority_out, direction_to_build, amount_of_buildings, building_size, building, build_orientation);
-			SeekStart();
 			break;
 
 			case e_filter:
@@ -272,7 +271,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				row_filter(currentStep, x_cord, y_cord, item, amount, check_input(building, splitter_list) ? "splitter" : "inserter", direction_to_build, amount_of_buildings, building_size, building, build_orientation);
-				SeekStart();
 				break;
 
 			case e_drop:
@@ -284,7 +282,6 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				SetBuildingAndOrientation(&steps[i]);
 
 				row_drop(currentStep, x_cord, y_cord, item, direction_to_build, amount_of_buildings, building_size, building);
-				SeekStart();
 				break;
 
 			case e_pick_up:
@@ -298,6 +295,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				break;
 
 			case e_save:
+				seek_start++;
 				save(currentStep, comment);
 				break;
 
@@ -1076,7 +1074,7 @@ void GenerateScript::row_take(string step, string x_cord, string y_cord, string 
 {
 
 	take(step, "1", x_cord, y_cord, amount, item, from, building, OrientationEnum);
-
+	SeekStart();
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1105,6 +1103,7 @@ void GenerateScript::put(string step, string action, string x_cord, string y_cor
 void GenerateScript::row_put(string step, string x_cord, string y_cord, string amount, string item, string from, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum)
 {
 	put(step, "1", x_cord, y_cord, amount, item, from, building, OrientationEnum);
+	SeekStart();
 
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
@@ -1128,7 +1127,7 @@ void GenerateScript::row_recipe(string step, string x_cord, string y_cord, strin
 {
 
 	recipe(step, "1", x_cord, y_cord, item, building, OrientationEnum);
-
+	SeekStart();
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1148,7 +1147,7 @@ void GenerateScript::limit(string step, string action, string x_cord, string y_c
 void GenerateScript::row_limit(string step, string x_cord, string y_cord, string amount, string from, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum)
 {
 	limit(step, "1", x_cord, y_cord, amount, from, building, OrientationEnum);
-
+	SeekStart();
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1171,7 +1170,7 @@ void GenerateScript::row_priority(string step, string x_cord, string y_cord, str
 	priority_out = convert_string(priority_out);
 
 	priority(step, "1", x_cord, y_cord, priority_in, priority_out, building, OrientationEnum);
-
+	SeekStart();
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1193,7 +1192,7 @@ void GenerateScript::filter(string step, string action, string x_cord, string y_
 void GenerateScript::row_filter(string step, string x_cord, string y_cord, string item, string amount, string type, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum)
 {
 	filter(step, "1", x_cord, y_cord, item, amount, type, building, OrientationEnum);
-
+	SeekStart();
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);
@@ -1215,7 +1214,7 @@ void GenerateScript::drop(string step, string action, string x_cord, string y_co
 void GenerateScript::row_drop(string step, string x_cord, string y_cord, string item, string direction, string number_of_buildings, string building_size, string building)
 {
 	drop(step, "1", x_cord, y_cord, item, building);
-
+	SeekStart();
 	for (int i = 1; i < std::stof(number_of_buildings); i++)
 	{
 		find_coordinates(x_cord, y_cord, direction, building_size);

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -259,34 +259,8 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				break;
 
 			case e_save:
-				if (i != 0 && i + 1 != amountOfSteps && last_walking_comment != "old")
-				{
-					// A save should be between two walk steps
-					if (steps[i - 1].StepEnum == e_walk && steps[i + 1].StepEnum == e_walk)
-					{
-						// The character should be running straight to ensure that the character doesn't start walking incorectly when the save is loaded.
-						if (steps[i - 1].X == steps[i + 1].X || steps[i - 1].Y == steps[i + 1].Y)
-						{
-							save(currentStep, comment);
-							break;
-						}
-					}
-
-					// Or the next step after the save needs to be a start step and the next after that should be a walk
-					if (i + 2 != amountOfSteps && steps[i + 1].StepEnum == e_start || steps[i + 2].StepEnum == e_walk)
-					{
-						// The character should be running straight to ensure that the character doesn't start walking incorectly when the save is loaded.
-						if (steps[i - 1].X == steps[i + 2].X || steps[i - 1].Y == steps[i + 2].Y)
-						{
-							save(currentStep, comment);
-							break;
-						}
-					}
-				}
-
-				wxMessageBox("A save step should be between two walk steps and the character has to be running straight (either X or Y of both walk steps should be same)", "Invalid Save", wxICON_WARNING);
-				dialog_progress_bar->Close();
-				return;
+				save(currentStep, comment);
+				break;
 
 			case e_idle:
 				idle(currentStep, amount);

--- a/src/GenerateScript.h
+++ b/src/GenerateScript.h
@@ -25,6 +25,7 @@ class GenerateScript
 {
 public:
 	GenerateScript();
+	void SeekStart();
 	void generate(wxWindow* parent, DialogProgressBar* dialog_progress_bar, vector<StepParameters> steps, string& folder_location, bool auto_close, bool only_generate_script, string goal);
 
 private:

--- a/src/GenerateScript.h
+++ b/src/GenerateScript.h
@@ -25,7 +25,6 @@ class GenerateScript
 {
 public:
 	GenerateScript();
-	void SeekStart();
 	void generate(wxWindow* parent, DialogProgressBar* dialog_progress_bar, vector<StepParameters> steps, string& folder_location, bool auto_close, bool only_generate_script, string goal);
 
 private:

--- a/src/OpenTas.cpp
+++ b/src/OpenTas.cpp
@@ -128,7 +128,11 @@ bool OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_progr
 		step.Direction = Capitalize(segments[6]);
 		step.Comment = comment;
 
-		step.StepEnum = MapStepNameToStepType.find(step.Step)->second;
+		auto mappedtype = MapStepNameToStepType.find(step.Step);
+		if (mappedtype == MapStepNameToStepType.end()) 
+			return false;
+
+		step.StepEnum = mappedtype->second;
 
 		switch (step.StepEnum)
 		{
@@ -220,7 +224,7 @@ bool OpenTas::extract_groups(std::ifstream& file, DialogProgressBar* dialog_prog
 		}
 
 		string comment = "";
-		if (segments.size() != group_segment_size)
+		if (segments.size() == group_segment_size)
 		{
 			comment = segments[10];
 		}
@@ -245,7 +249,7 @@ bool OpenTas::extract_groups(std::ifstream& file, DialogProgressBar* dialog_prog
 			step.Buildings = stoi(segments[9]);
 		}
 
-		step.Step = Capitalize(segments[1]);
+		step.Step = Capitalize(segments[0]);
 		step.Amount = Capitalize(segments[4]);
 		step.Item = Capitalize(segments[5], true);
 		step.Orientation = Capitalize(segments[6]);

--- a/src/OpenTas.cpp
+++ b/src/OpenTas.cpp
@@ -249,14 +249,17 @@ bool OpenTas::extract_groups(std::ifstream& file, DialogProgressBar* dialog_prog
 			step.Buildings = stoi(segments[9]);
 		}
 
-		step.Step = Capitalize(segments[0]);
+		step.Step = Capitalize(segments[1]);
 		step.Amount = Capitalize(segments[4]);
 		step.Item = Capitalize(segments[5], true);
 		step.Orientation = Capitalize(segments[6]);
 		step.Direction = Capitalize(segments[7]);
 		step.Comment = comment;
 
-		step.StepEnum = MapStepNameToStepType.find(step.Step)->second;
+		auto mappedtype = MapStepNameToStepType.find(step.Step);
+		if (mappedtype == MapStepNameToStepType.end())
+			return false;
+		step.StepEnum = mappedtype->second;
 
 		steps.push_back(step);
 

--- a/src/OpenTas.cpp
+++ b/src/OpenTas.cpp
@@ -311,7 +311,7 @@ bool OpenTas::extract_templates(std::ifstream& file, DialogProgressBar* dialog_p
 		}
 
 		string comment = "";
-		if (segments.size() != group_segment_size)
+		if (segments.size() == group_segment_size)
 		{
 			comment = segments[10];
 		}

--- a/src/StepNameToEnum.h
+++ b/src/StepNameToEnum.h
@@ -32,7 +32,7 @@ static const vector<string> StepNames{
 /// <summary>
 /// Maps StepName(string) to StepType(enum)
 /// </summary>
-static const map<string, StepType> MapStepNameToStepType = {{"Start", e_start}, {"Stop", e_stop}, {"Build", e_build}, {"Craft", e_craft}, {"Game Speed", e_game_speed}, {"Pause", e_pause}, {"Save", e_save},
+static const map<string, StepType> MapStepNameToStepType = {{"Start", e_start}, {"Stop", e_stop}, {"Build", e_build}, {"Craft", e_craft}, {"Game speed", e_game_speed}, {"Pause", e_pause}, {"Save", e_save},
 	{"Recipe", e_recipe}, {"Limit", e_limit}, {"Filter", e_filter}, {"Rotate", e_rotate}, {"Priority", e_priority}, {"Put", e_put}, {"Take", e_take}, {"Mine", e_mine}, {"Launch", e_launch},
 	{"Walk", e_walk}, {"Tech", e_tech}, {"Drop", e_drop}, {"Pick up", e_pick_up}, {"Idle", e_idle}};
 


### PR DESCRIPTION
**Reversed changes to save and start.**

**Save global**
Now you can just insert a save command, and then load that save. No need for start anymore.

Added lua global tas data, to be persistent between saves
Added methods to migrate data to and from global tas data
Re-added queued save, which queues in the pre-tick and executes in post-tick

Known bug, if you have multiple saves in one pre-tick it will only execute the last one.

I had to change line 644 `return {walking = false, direction = walking.direction}` because it didn't always get initialized properly, tell me if this is an issue.

I tested it with every save from the script i sent @MortenTobiasNielsen , in single player everything is fine. In multiplayer i sometimes got some factorio crashes which i believe is due to making too many saves. I can't debug in MP, but the stack trace doesn't show any mods. I don't think it is a huge issue.